### PR TITLE
Fast saturation with cuboid and numpy histo + SRIM converter

### DIFF
--- a/ConfigFile_new.txt
+++ b/ConfigFile_new.txt
@@ -28,15 +28,15 @@
 'noiserun'              : 4159,      # pedestal run to add as background
 
 'ion_pot'               : 0.0462,    # ionization potential for He/CF4 60/40 [keV]
-'GEM1_HV'               : [440., 400., 360., 320.],      # HV of GEM1
-'GEM2_HV'               : [440., 400., 360., 320.],      # HV of GEM2
-'GEM3_HV'               : [440., 400., 360., 320.],      # HV of GEM3
+'GEM1_HV'               : [420.],  # HV of GEM1
+'GEM2_HV'               : [420.],  # HV of GEM2
+'GEM3_HV'               : [420.],  # HV of GEM3
 
 
 'A'                     : 1.,        # free parameter (total scale factor MC/data) 
 'beta'                  : 0.5e-5,    # saturation parameter
 'absorption_l'          : 1000.,     # absorption lenght in [mm]
-'saturation'            : False,     
+'saturation'            : True,     
 
 'photons_per_el'        : 0.07,      # number of photons per electron produced in the avalanche
 'counts_per_photon'     : 2.,        # sensor conversion factor counts/photons

--- a/ConfigFile_new.txt
+++ b/ConfigFile_new.txt
@@ -19,7 +19,7 @@
 'y_vox_max'		: 1300,      # y voxel max of the electron cloud (voxels in the GEM plane correspond to pixels)
 
 #FIXME
-'z_gem'			: 200.,      # distance from GEM [mm]
+'z_gem'			: 200.,      # GEM z coordinate [mm] (Note that in Geant4 CYGNO simulation the center of sensitive region is at 255. mm)
 'tag'			: 'MC',
 'noiserun'              : 4159,      # pedestal run to add as background
 

--- a/ConfigFile_new.txt
+++ b/ConfigFile_new.txt
@@ -1,21 +1,40 @@
 {
-#'diff_coeff_B' 		: 0.0170,    #diffusion parameter [mm/sqrt(cm)]^2
-#'diff_const_sigma0'	: 0.0853,	    # diffusion constant [mm]^2
 ##from https://arxiv.org/pdf/2007.00608.pdf
-'diff_coeff_B' 		: 0.0196,    #diffusion parameter [mm/sqrt(cm)]^2
-'diff_const_sigma0'	: 0.0784,	    # diffusion constant [mm]^2
-'z_dim'			: 330,      #first dimension of the detector
-'y_dim'			: 330,      #second dimension of the detector
-'z_pix'			: 2304,      #number of pixels in the first dimension
+'diff_const_sigma0T'	: 0.0784,	    # diffusion constant [mm]^2
+'diff_coeff_T' 		: 0.0196,    #diffusion parameter [mm/sqrt(cm)]^2 
+'diff_const_sigma0L'	: 0.0676,	    # diffusion constant [mm]^2
+'diff_coeff_L' 		: 0.0144,    #diffusion parameter [mm/sqrt(cm)]^2
+
+'x_dim'			: 350,      #first dimension of the detector
+'y_dim'			: 350,      #second dimension of the detector
+'x_pix'			: 2304,      #number of pixels in the first dimension
 'y_pix'			: 2304,      #number of pixels in the second dimension
-'x_gem'			: 510,       #coordinate of the cam in the simulation (x the is drift direction in geant4 sim) [mm]
-'noise_mean'		: 99,        #Electronic noise mean value per pixel
-'noise_sigma'		: 2,         #Electronic noise sigma
+
+'z_vox_dim'             : 0.1, #mm
+
+#FIXME
+'z_gem'			: 455.,       #distance from the GEM is (z_gem-255.) [mm]
 'tag'			: 'Data',
-'noiserun'		: 3797, 
-'Conversion_Factor'	: 3000./6,   #Number of photoelectrons emitted per keV (iron calibration) [LIME has 60% light wrt LEMON]
-'bckg'			: True,     #if 'True' background is added
+'noiserun'		: 3944, 
+
+'ion_pot'               : 0.0462,    #ionization potential for He/CF4 60/40 [keV]
+'GEM1_HV'               : 450., 
+'GEM2_HV'               : 450., 
+'GEM3_HV'               : 450., 
+'extraction_eff'        : 0.37,
+
+'A'                     : 1.4705882,
+'beta'                  : 2.5e-5,
+'absorption_l'          : 1000,       #mm
+'saturation'            : 1,     # 1=yes, 0=no
+
+'photons_per_el'        : 0.07,    #number of photons per electron produced in the avalanche
+'counts_per_photon'     : 2.,      #sensor conversion factor counts/photons
+'sensor_size'           : 14.976,      #sensor dimension [mm] ORCA Fusion
+'camera_aperture'       : 0.95,
+
+'bckg'			: False,     #if 'True' background is added
 'rootfiles'             : True,     #choose input type: True for G4 root iput, False for SRIM txt files
-'events'                : 20,       #number of events to be processed, -1 = all
+'events'                : 10,       #number of events to be processed, -1 = all
 'donotremove'           : True,                    # Remove or not the file from the tmp folder
 }

--- a/ConfigFile_new.txt
+++ b/ConfigFile_new.txt
@@ -1,45 +1,46 @@
 {
 ##from https://arxiv.org/pdf/2007.00608.pdf
-'diff_const_sigma0T'    : 0.0784,           # diffusion constant [mm]^2
-'diff_coeff_T'          : 0.01232,    #diffusion parameter [mm/sqrt(cm)]^2 for 1 kV
-'diff_const_sigma0L'    : 0.0676,           # diffusion constant [mm]^2
-'diff_coeff_L'          : 0.00978,    #diffusion parameter [mm/sqrt(cm)]^2 for 1 kV
+'diff_const_sigma0T'    : 0.0784,     # diffusion constant [mm]^2
+'diff_coeff_T'          : 0.01232,    # diffusion parameter [mm/sqrt(cm)]^2 for 1 kV
+'diff_const_sigma0L'    : 0.0676,     # diffusion constant [mm]^2
+'diff_coeff_L'          : 0.00978,    # diffusion parameter [mm/sqrt(cm)]^2 for 1 kV
 
 
-'x_dim'			: 350,      #first dimension of the detector
-'y_dim'			: 350,      #second dimension of the detector
-'x_pix'			: 2304,      #number of pixels in the first dimension
-'y_pix'			: 2304,      #number of pixels in the second dimension
+'x_dim'			: 350,       # first dimension of the detector
+'y_dim'			: 350,       # second dimension of the detector
+'x_pix'			: 2304,      # number of pixels in the first dimension
+'y_pix'			: 2304,      # number of pixels in the second dimension
 
-'z_vox_dim'             : 0.1, #mm
-'zcloud'		: 20, #mm
-'x_vox_min'		: 1100, #px 
-'x_vox_max'		: 1400, #px 
-'y_vox_min'		: 1100, #px 
-'y_vox_max'		: 1400, #px 
+'z_vox_dim'             : 0.1,       # z voxel size in [mm]
+'zcloud'		: 20,        # z dimension of the electron cloud in [mm]
+'x_vox_min'		: 1000,      # x voxel min of the electron cloud (voxels in the GEM plane correspond to pixels)
+'x_vox_max'		: 1300,      # x voxel max of the electron cloud (voxels in the GEM plane correspond to pixels)
+'y_vox_min'		: 1000,      # y voxel min of the electron cloud (voxels in the GEM plane correspond to pixels)
+'y_vox_max'		: 1300,      # y voxel max of the electron cloud (voxels in the GEM plane correspond to pixels)
 
 #FIXME
-'z_gem'			: 200.,       #distance [mm]
-'tag'			: 'Data',
-'noiserun'              : 4159, 
+'z_gem'			: 200.,      # distance from GEM [mm]
+'tag'			: 'MC',
+'noiserun'              : 4159,      # pedestal run to add as background
 
-'ion_pot'               : 0.0462,    #ionization potential for He/CF4 60/40 [keV]
-'GEM1_HV'               : 440., 
-'GEM2_HV'               : 440., 
-'GEM3_HV'               : 440., 
+'ion_pot'               : 0.0462,    # ionization potential for He/CF4 60/40 [keV]
+'GEM1_HV'               : 440.,      # HV of GEM1
+'GEM2_HV'               : 440.,      # HV of GEM2
+'GEM3_HV'               : 440.,      # HV of GEM3
 
-'A'                     : 1.,
-'beta'                  : 0.5e-5,
-'absorption_l'          : 1000.,       #mm
+
+'A'                     : 1.,        # free parameter (total scale factor MC/data) 
+'beta'                  : 0.5e-5,    # saturation parameter
+'absorption_l'          : 1000.,     # absorption lenght in [mm]
 'saturation'            : True,     
 
-'photons_per_el'        : 0.07,    #number of photons per electron produced in the avalanche
-'counts_per_photon'     : 2.,      #sensor conversion factor counts/photons
-'sensor_size'           : 14.976,      #sensor dimension [mm] ORCA Fusion
+'photons_per_el'        : 0.07,      # number of photons per electron produced in the avalanche
+'counts_per_photon'     : 2.,        # sensor conversion factor counts/photons
+'sensor_size'           : 14.976,    # sensor dimension [mm] ORCA Fusion
 'camera_aperture'       : 0.95,
 
-'bckg'                  : False,     #if 'True' background is added
-'rootfiles'             : False,     #choose input type: True for G4 root iput, False for SRIM txt files
-'events'                : 1,       #number of events to be processed, -1 = all
-'donotremove'           : True,                    # Remove or not the file from the tmp folder
+'bckg'                  : False,     # if 'True' background is added
+'rootfiles'             : False,     # choose input type: True for G4 root iput, False for SRIM txt files
+'events'                : 1,         # number of events to be processed, -1 = all
+'donotremove'           : True,      # Remove or not the file from the tmp folder
 }

--- a/ConfigFile_new.txt
+++ b/ConfigFile_new.txt
@@ -1,9 +1,10 @@
 {
 ##from https://arxiv.org/pdf/2007.00608.pdf
-'diff_const_sigma0T'	: 0.0784,	    # diffusion constant [mm]^2
-'diff_coeff_T' 		: 0.0196,    #diffusion parameter [mm/sqrt(cm)]^2 
-'diff_const_sigma0L'	: 0.0676,	    # diffusion constant [mm]^2
-'diff_coeff_L' 		: 0.0144,    #diffusion parameter [mm/sqrt(cm)]^2
+'diff_const_sigma0T'    : 0.0784,           # diffusion constant [mm]^2
+'diff_coeff_T'          : 0.01232,    #diffusion parameter [mm/sqrt(cm)]^2 for 1 kV
+'diff_const_sigma0L'    : 0.0676,           # diffusion constant [mm]^2
+'diff_coeff_L'          : 0.00978,    #diffusion parameter [mm/sqrt(cm)]^2 for 1 kV
+
 
 'x_dim'			: 350,      #first dimension of the detector
 'y_dim'			: 350,      #second dimension of the detector
@@ -11,30 +12,34 @@
 'y_pix'			: 2304,      #number of pixels in the second dimension
 
 'z_vox_dim'             : 0.1, #mm
+'zcloud'		: 20, #mm
+'x_vox_min'		: 1100, #px 
+'x_vox_max'		: 1400, #px 
+'y_vox_min'		: 1100, #px 
+'y_vox_max'		: 1400, #px 
 
 #FIXME
-'z_gem'			: 455.,       #distance from the GEM is (z_gem-255.) [mm]
+'z_gem'			: 200.,       #distance [mm]
 'tag'			: 'Data',
-'noiserun'		: 3944, 
+'noiserun'              : 4159, 
 
 'ion_pot'               : 0.0462,    #ionization potential for He/CF4 60/40 [keV]
-'GEM1_HV'               : 450., 
-'GEM2_HV'               : 450., 
-'GEM3_HV'               : 450., 
-'extraction_eff'        : 0.37,
+'GEM1_HV'               : 440., 
+'GEM2_HV'               : 440., 
+'GEM3_HV'               : 440., 
 
-'A'                     : 1.4705882,
-'beta'                  : 2.5e-5,
-'absorption_l'          : 1000,       #mm
-'saturation'            : 1,     # 1=yes, 0=no
+'A'                     : 1.,
+'beta'                  : 0.5e-5,
+'absorption_l'          : 1000.,       #mm
+'saturation'            : True,     
 
 'photons_per_el'        : 0.07,    #number of photons per electron produced in the avalanche
 'counts_per_photon'     : 2.,      #sensor conversion factor counts/photons
 'sensor_size'           : 14.976,      #sensor dimension [mm] ORCA Fusion
 'camera_aperture'       : 0.95,
 
-'bckg'			: False,     #if 'True' background is added
-'rootfiles'             : True,     #choose input type: True for G4 root iput, False for SRIM txt files
-'events'                : 10,       #number of events to be processed, -1 = all
+'bckg'                  : False,     #if 'True' background is added
+'rootfiles'             : False,     #choose input type: True for G4 root iput, False for SRIM txt files
+'events'                : 1,       #number of events to be processed, -1 = all
 'donotremove'           : True,                    # Remove or not the file from the tmp folder
 }

--- a/ConfigFile_new.txt
+++ b/ConfigFile_new.txt
@@ -19,7 +19,7 @@
 'y_vox_max'		: 1300,      # y voxel max of the electron cloud (voxels in the GEM plane correspond to pixels)
 
 #FIXME
-'z_gem'			: 200.,      # GEM z coordinate [mm] (Note that in Geant4 CYGNO simulation the center of sensitive region is at 255. mm)
+'z_gem'			: 255.+200.,      # GEM z coordinate [mm] (Note: in Geant4 CYGNO simulation the center of sensitive region is at 255. mm. So you need to add 255mm)
 'tag'			: 'MC',
 'noiserun'              : 4159,      # pedestal run to add as background
 

--- a/ConfigFile_new.txt
+++ b/ConfigFile_new.txt
@@ -1,3 +1,7 @@
+# For each parameter you can either set a single value or a list of values. This allows you to easily run the simulation multiple times with differet paramters. 
+# Each list represents the sequence of paramters the simulation will use for each run. Single-value paramters are interpreted as fixed values (the same for each run).
+# Note: you can set as many lists as you want, as long as the length is the same, this can be useful for a HV-scan where 3 paramters (GEM1_HV, GEM2_HV and GEM3_HV) change for each run.
+
 {
 ##from https://arxiv.org/pdf/2007.00608.pdf
 'diff_const_sigma0T'    : 0.0784,     # diffusion constant [mm]^2
@@ -19,14 +23,14 @@
 'y_vox_max'		: 1300,      # y voxel max of the electron cloud (voxels in the GEM plane correspond to pixels)
 
 #FIXME
-'z_gem'			: 255.+200., # GEM z coordinate [mm] (Note: in Geant4 CYGNO simulation the center of sensitive region is at 255. mm. So you need to add 255mm)
+'z_gem'			: 255.+200.,      # GEM z coordinate [mm] (Note: in Geant4 CYGNO simulation the center of sensitive region is at 255. mm. So you need to add 255mm)
 'tag'			: 'MC',
 'noiserun'              : 4159,      # pedestal run to add as background
 
 'ion_pot'               : 0.0462,    # ionization potential for He/CF4 60/40 [keV]
-'GEM1_HV'               : 440.,      # HV of GEM1
-'GEM2_HV'               : 440.,      # HV of GEM2
-'GEM3_HV'               : 440.,      # HV of GEM3
+'GEM1_HV'               : [440., 400., 360., 320.],      # HV of GEM1
+'GEM2_HV'               : [440., 400., 360., 320.],      # HV of GEM2
+'GEM3_HV'               : [440., 400., 360., 320.],      # HV of GEM3
 
 
 'A'                     : 1.,        # free parameter (total scale factor MC/data) 

--- a/ConfigFile_new.txt
+++ b/ConfigFile_new.txt
@@ -19,7 +19,7 @@
 'y_vox_max'		: 1300,      # y voxel max of the electron cloud (voxels in the GEM plane correspond to pixels)
 
 #FIXME
-'z_gem'			: 255.+200.,      # GEM z coordinate [mm] (Note: in Geant4 CYGNO simulation the center of sensitive region is at 255. mm. So you need to add 255mm)
+'z_gem'			: 255.+200., # GEM z coordinate [mm] (Note: in Geant4 CYGNO simulation the center of sensitive region is at 255. mm. So you need to add 255mm)
 'tag'			: 'MC',
 'noiserun'              : 4159,      # pedestal run to add as background
 
@@ -32,7 +32,7 @@
 'A'                     : 1.,        # free parameter (total scale factor MC/data) 
 'beta'                  : 0.5e-5,    # saturation parameter
 'absorption_l'          : 1000.,     # absorption lenght in [mm]
-'saturation'            : True,     
+'saturation'            : False,     
 
 'photons_per_el'        : 0.07,      # number of photons per electron produced in the avalanche
 'counts_per_photon'     : 2.,        # sensor conversion factor counts/photons
@@ -40,7 +40,7 @@
 'camera_aperture'       : 0.95,
 
 'bckg'                  : False,     # if 'True' background is added
-'rootfiles'             : False,     # choose input type: True for G4 root iput, False for SRIM txt files
+'rootfiles'             : True,     # choose input type: True for G4 root iput, False for SRIM txt files
 'events'                : 1,         # number of events to be processed, -1 = all
 'donotremove'           : True,      # Remove or not the file from the tmp folder
 }

--- a/ConfigFile_new.txt
+++ b/ConfigFile_new.txt
@@ -17,10 +17,10 @@
 
 'z_vox_dim'             : 0.1,       # z voxel size in [mm]
 'zcloud'		: 20,        # z dimension of the electron cloud in [mm]
-'x_vox_min'		: 1000,      # x voxel min of the electron cloud (voxels in the GEM plane correspond to pixels)
-'x_vox_max'		: 1300,      # x voxel max of the electron cloud (voxels in the GEM plane correspond to pixels)
-'y_vox_min'		: 1000,      # y voxel min of the electron cloud (voxels in the GEM plane correspond to pixels)
-'y_vox_max'		: 1300,      # y voxel max of the electron cloud (voxels in the GEM plane correspond to pixels)
+#'x_vox_min'		: 1000,      # x voxel min of the electron cloud (voxels in the GEM plane correspond to pixels)
+#'x_vox_max'		: 1300,      # x voxel max of the electron cloud (voxels in the GEM plane correspond to pixels)
+#'y_vox_min'		: 1000,      # y voxel min of the electron cloud (voxels in the GEM plane correspond to pixels)
+#'y_vox_max'		: 1300,      # y voxel max of the electron cloud (voxels in the GEM plane correspond to pixels)
 
 #FIXME
 'z_gem'			: 255.+200.,      # GEM z coordinate [mm] (Note: in Geant4 CYGNO simulation the center of sensitive region is at 255. mm. So you need to add 255mm)

--- a/MC_data_new.py
+++ b/MC_data_new.py
@@ -155,12 +155,15 @@ if __name__ == "__main__":
     for k,v in params.items():
         setattr(opt, k, v)
 
+    ## fit from Fernando Amaro's single GEM gain measurement
     GEM1_gain = 0.0347*np.exp((0.0209)*opt.GEM1_HV)
     GEM2_gain = 0.0347*np.exp((0.0209)*opt.GEM2_HV)
     GEM3_gain = 0.0347*np.exp((0.0209)*opt.GEM3_HV)
     print("GEM1_gain = %d"%GEM1_gain)
     print("GEM2_gain = %d"%GEM2_gain)
     print("GEM3_gain = %d"%GEM3_gain)
+    
+    ## dividing Fernando's to Francesco&Karolina's single GEM gain measurement
     extraction_eff_GEM1 = 0.87319885*np.exp(-0.0020000000*opt.GEM1_HV)
     extraction_eff_GEM2 = 0.87319885*np.exp(-0.0020000000*opt.GEM2_HV)
     extraction_eff_GEM3 = 0.87319885*np.exp(-0.0020000000*opt.GEM3_HV)

--- a/MC_data_new.py
+++ b/MC_data_new.py
@@ -200,7 +200,7 @@ if __name__ == "__main__":
                 #FIXME
                 z_ini = 255.
                 zbins = int(opt.zcloud/opt.z_vox_dim)
-                rootfile=rt.TFile.Open(opt.infolder+infile)
+                rootfile=rt.TFile.Open(opt.infolder+"/"+infile)
                 tree=rootfile.Get('nTuple')            #GETTING NTUPLES
             
                 infilename=infile[:-5]    
@@ -305,7 +305,7 @@ if __name__ == "__main__":
             # code to be used with input txt files from SRIM
             if infile.endswith('.txt'):    #KEEPING part.txt FILES ONLY NB: one single file with a specific name for the moment. there are other .txt files in the folder...this has to be fixed...
 
-                textfile=open(opt.infolder+infile, "r")
+                textfile=open(opt.infolder+"/"+infile, "r")
                 print("Opening file : %s" %infile )
 
                 infilename=infile[:-4]    

--- a/MC_data_new.py
+++ b/MC_data_new.py
@@ -121,7 +121,7 @@ def SaveValues(par, out):
 
     return None
 
-def SaveEventInfo(info_dict, folder, out):
+def SaveEventInfo(info_dict, folder, out):  # THIS FUNCTION IS CURRENTLY NOT USED 
     
     out.cd()
     #gDirectory.pwd()
@@ -150,386 +150,410 @@ if __name__ == "__main__":
     (opt, args) = parser.parse_args()
 
     config = open(args[0], "r")         #GET CONFIG FILE
-    params = eval(config.read())         #READ CONFIG FILE
+    params_with_list = eval(config.read())         #READ CONFIG FILE
 
-    for k,v in params.items():
-        setattr(opt, k, v)
 
-    ## fit from Fernando Amaro's single GEM gain measurement
-    GEM1_gain = 0.0347*np.exp((0.0209)*opt.GEM1_HV)
-    GEM2_gain = 0.0347*np.exp((0.0209)*opt.GEM2_HV)
-    GEM3_gain = 0.0347*np.exp((0.0209)*opt.GEM3_HV)
-    print("GEM1_gain = %d"%GEM1_gain)
-    print("GEM2_gain = %d"%GEM2_gain)
-    print("GEM3_gain = %d"%GEM3_gain)
+    # PREPARE A LOOP OVER THE CONFIG PARAMETERS. SINGLE VALUES ARE INTERPRETED AS FIXED VALUES. 
+    scan_par_list=[]
+    scan_length=1       
+
+    # CHECK WHICH PARAMETERS ARE IN FORM OF LISTS
+    for k,v in params_with_list.items():
+        if isinstance(v, list):
+            scan_par_list.append(k)
+            scan_length=len(v)   # A CHECK ON THE LENGTH OF LISTS SHOULD BE DONE -> ALL LIST MUST HAVE THE SAME LENGTH 
     
-    ## dividing Fernando's to Francesco&Karolina's single GEM gain measurement
-    extraction_eff_GEM1 = 0.87319885*np.exp(-0.0020000000*opt.GEM1_HV)
-    extraction_eff_GEM2 = 0.87319885*np.exp(-0.0020000000*opt.GEM2_HV)
-    extraction_eff_GEM3 = 0.87319885*np.exp(-0.0020000000*opt.GEM3_HV)
-    print("extraction eff GEM1 = %f" % extraction_eff_GEM1 )
-    print("extraction eff GEM2 = %f" % extraction_eff_GEM2 )
-    print("extraction eff GEM3 = %f" % extraction_eff_GEM3 )
-
-    demag=opt.y_dim/opt.sensor_size
-    a=opt.camera_aperture
-    omega=1./math.pow((4*(demag+1)*a),2)   # solid angle ratio
-    #print(omega)
-
-#### CODE EXECUTION ####
-    run_count=1
-    t0=time.time()
+    # TURN NON-LIST INTO TRIVIAL LIST: A LIST WHERE EACH ELEMENT IS THE SAME
+    for k,v in params_with_list.items():
+        if k not in scan_par_list:
+            params_with_list[k]=[v]*scan_length
+        elif k in scan_par_list:
+            params_with_list[k]=v
    
-    # UNCOMMENT THIS LINE IF YOU WANT TO STUDY THE SIMULATION WITH THE SAME STATISTICAL FLUCTUATIONS (SAME SEED): IT IS USEFUL FOR DEBUGGING
-    np.random.seed(seed=0)
+    # NOW SCAN OVER MULTIPLE PARAMETERS
+    for scan_idx in range(0,scan_length):
+        params={}
+        for k, v in params_with_list.items():
+            params[k] = v[scan_idx]
+
+        for k,v in params.items():
+            setattr(opt, k, v)
+
+        ## fit from Fernando Amaro's single GEM gain measurement
+        GEM1_gain = 0.0347*np.exp((0.0209)*opt.GEM1_HV)
+        GEM2_gain = 0.0347*np.exp((0.0209)*opt.GEM2_HV)
+        GEM3_gain = 0.0347*np.exp((0.0209)*opt.GEM3_HV)
+        print("GEM1_gain = %d"%GEM1_gain)
+        print("GEM2_gain = %d"%GEM2_gain)
+        print("GEM3_gain = %d"%GEM3_gain)
+        
+        ## dividing Fernando's to Francesco&Karolina's single GEM gain measurement
+        extraction_eff_GEM1 = 0.87319885*np.exp(-0.0020000000*opt.GEM1_HV)
+        extraction_eff_GEM2 = 0.87319885*np.exp(-0.0020000000*opt.GEM2_HV)
+        extraction_eff_GEM3 = 0.87319885*np.exp(-0.0020000000*opt.GEM3_HV)
+        print("extraction eff GEM1 = %f" % extraction_eff_GEM1 )
+        print("extraction eff GEM2 = %f" % extraction_eff_GEM2 )
+        print("extraction eff GEM3 = %f" % extraction_eff_GEM3 )
+
+        demag=opt.y_dim/opt.sensor_size
+        a=opt.camera_aperture
+        omega=1./math.pow((4*(demag+1)*a),2)   # solid angle ratio
+        #print(omega)
+
+    #### CODE EXECUTION ####
+        run_count=1
+        t0=time.time()
+       
+        # UNCOMMENT THIS LINE IF YOU WANT TO STUDY THE SIMULATION WITH THE SAME STATISTICAL FLUCTUATIONS (SAME SEED): IT IS USEFUL FOR DEBUGGING
+        #np.random.seed(seed=0)
 
 
-    eventnumber = np.array([-999], dtype="int")
-    particle_type = np.array([-999], dtype="int")
-    energy_ini = np.array([-999], dtype="float32")
-    theta_ini = np.array([-999], dtype="float32")
-    phi_ini = np.array([-999], dtype="float32")
+        eventnumber = np.array([-999], dtype="int")
+        particle_type = np.array([-999], dtype="int")
+        energy_ini = np.array([-999], dtype="float32")
+        theta_ini = np.array([-999], dtype="float32")
+        phi_ini = np.array([-999], dtype="float32")
 
-    z_ini = 0
+        z_ini = 0
 
-    if not os.path.exists(opt.outfolder): #CREATING OUTPUT FOLDER
-        os.makedirs(opt.outfolder)
-            
-    for infile in os.listdir(opt.infolder): #READING INPUT FOLDER
-            
-        if opt.rootfiles==True:
-                # code to be used with input root files from Geant
-            if infile.endswith('.root'):    #KEEPING .ROOT FILES ONLY
+        if not os.path.exists(opt.outfolder): #CREATING OUTPUT FOLDER
+            os.makedirs(opt.outfolder)
                 
-                #FIXME
-                z_ini = 255.
-                zbins = int(opt.zcloud/opt.z_vox_dim)
-                rootfile=rt.TFile.Open(opt.infolder+"/"+infile)
-                tree=rootfile.Get('nTuple')            #GETTING NTUPLES
-            
-                infilename=infile[:-5]    
-                #outfile=rt.TFile('%s/histograms_Run%05d.root' % (opt.outfolder,run_count), 'RECREATE') #OUTPUT NAME (only run number)
-                #outfile=rt.TFile('%s/histograms_%s_%d_mm_%d_V.root' % (opt.outfolder, infilename, opt.z_gem-z_ini, opt.GEM1_HV), 'RECREATE') #OUTPUT NAME WITH PARAMETERS INFO
-                outfile=rt.TFile('%s/histograms_%s_%d_mm_%d_V_%s.root' % (opt.outfolder, infilename, opt.z_gem-z_ini, opt.GEM1_HV, time.strftime("%Y%m%d-%H%M%S") ), 'RECREATE') #OUTPUT NAME WITH PARAMETERS INFO AND TIMESTAMP
-                outfile.mkdir('event_info')
-                SaveValues(params, outfile) ## SAVE PARAMETERS OF THE RUN
-                outtree = rt.TTree("info_tree", "info_tree")
-                outtree.Branch("eventnumber", eventnumber, "eventnumber/I")
-                outtree.Branch("particle_type", particle_type, "particle_type/I")
-                outtree.Branch("energy_ini", energy_ini, "energy_ini/F")
-                outtree.Branch("theta_ini", theta_ini, "theta_ini/F")
-                outtree.Branch("phi_ini", phi_ini, "phi_ini/F")
-
-                final_imgs=list();
+        for infile in os.listdir(opt.infolder): #READING INPUT FOLDER
                 
-                if opt.events==-1:
-                    totev=tree.GetEntries()
-                else:
+            if opt.rootfiles==True:
+                    # code to be used with input root files from Geant
+                if infile.endswith('.root'):    #KEEPING .ROOT FILES ONLY
                     
-                    if opt.events<=tree.GetEntries():
-                        totev=opt.events
-                    else:
-                        totev=tree.GetEntries()
-                    
-
-    
-                for entry in range(0, totev): #RUNNING ON ENTRIES
-                    tree.GetEntry(entry)
-                    eventnumber[0] = tree.eventnumber
                     #FIXME
-                    particle_type[0] = 0
-                    energy_ini[0] = tree.ekin_particle[0]*1000
-                    phi_ini[0] = -999.
-                    theta_ini[0] = -999.
-                    phi_ini[0] = np.arctan2( (tree.y_hits[1]-tree.y_hits[0]),(tree.z_hits[1]-tree.z_hits[0]) )
-                    theta_ini[0] = np.arccos( (tree.x_hits[1]-tree.x_hits[0]) / np.sqrt( np.power((tree.x_hits[1]-tree.x_hits[0]),2) + np.power((tree.y_hits[1]-tree.y_hits[0]),2) + np.power((tree.z_hits[1]-tree.z_hits[0]),2)) )
-                    outtree.Fill()
-                    final_image=rt.TH2I('pic_run'+str(run_count)+'_ev'+str(entry), '', opt.x_pix, 0, opt.x_pix-1, opt.y_pix, 0, opt.y_pix-1) #smeared track with background
+                    z_ini = 255.
+                    zbins = int(opt.zcloud/opt.z_vox_dim)
+                    rootfile=rt.TFile.Open(opt.infolder+"/"+infile)
+                    tree=rootfile.Get('nTuple')            #GETTING NTUPLES
+                
+                    infilename=infile[:-5]    
+                    #outfile=rt.TFile('%s/histograms_Run%05d.root' % (opt.outfolder,run_count), 'RECREATE') #OUTPUT NAME (only run number)
+                    #outfile=rt.TFile('%s/histograms_%s_%d_mm_%d_V.root' % (opt.outfolder, infilename, opt.z_gem-z_ini, opt.GEM1_HV), 'RECREATE') #OUTPUT NAME WITH PARAMETERS INFO
+                    outfile=rt.TFile('%s/histograms_%s_%d_mm_%d_V_%s.root' % (opt.outfolder, infilename, opt.z_gem-z_ini, opt.GEM1_HV, time.strftime("%Y%m%d-%H%M%S") ), 'RECREATE') #OUTPUT NAME WITH PARAMETERS INFO AND TIMESTAMP
+                    outfile.mkdir('event_info')
+                    SaveValues(params, outfile) ## SAVE PARAMETERS OF THE RUN
+                    outtree = rt.TTree("info_tree", "info_tree")
+                    outtree.Branch("eventnumber", eventnumber, "eventnumber/I")
+                    outtree.Branch("particle_type", particle_type, "particle_type/I")
+                    outtree.Branch("energy_ini", energy_ini, "energy_ini/F")
+                    outtree.Branch("theta_ini", theta_ini, "theta_ini/F")
+                    outtree.Branch("phi_ini", phi_ini, "phi_ini/F")
 
-
+                    final_imgs=list();
                     
-                    ## with saturation
-                    if (opt.saturation):
-                        histname = "histo_cloud_pic_"+str(run_count)+"_ev"+str(int(entry)) 
-                        histo_cloud = rt.TH3I(histname,"",opt.x_pix,0,opt.x_pix-1,opt.y_pix,0,opt.y_pix-1,zbins,0,zbins)
-                        #print("created histo_cloud")
-                        tot_el_G2 = 0
-                        for ihit in range(0,tree.numhits):
-                            #print("Processing hit %d of %d"%(ihit,tree.numhits))
-
-                            ## here swapping X with Z beacuse in geant the drift axis is X
-                            S3D = cloud_smearing3D(tree.z_hits[ihit],tree.y_hits[ihit],tree.x_hits[ihit],tree.energyDep_hits[ihit],opt)
-
-                            for j in range(0, len(S3D[0])):
-                                histo_cloud.Fill((0.5*opt.x_dim+S3D[0][j])*opt.x_pix/opt.x_dim, (0.5*opt.y_dim+S3D[1][j])*opt.y_pix/opt.y_dim, (0.5*histo_cloud.GetNbinsZ()*opt.z_vox_dim+S3D[2][j])/opt.z_vox_dim ) 
-                                tot_el_G2+=1
-                                
-                        #tot_el_G2 = histo_cloud.Integral()
-                    
-                        # 2d map of photons applying saturation effect
-                        result_GEM3 = Nph_saturation(histo_cloud,opt)
-                        array2d_Nph = result_GEM3[1]
-                        #tot_ph_G3 = result_GEM3[0] 
-                        tot_ph_G3 = np.sum(array2d_Nph)
-
-                        #print("tot num of sensor counts after GEM3 including saturation: %d"%(tot_ph_G3))
-                        #print("tot num of sensor counts after GEM3 without saturation: %d"%(opt.A*tot_el_G2*GEM3_gain* omega * opt.photons_per_el * opt.counts_per_photon))
-                        #print("Gain GEM3 = %f   Gain GEM3 saturated = %f"%(GEM3_gain, tot_ph_G3/(opt.A * tot_el_G2*omega * opt.photons_per_el * opt.counts_per_photon) ))   
-
-                    ## no saturation
+                    if opt.events==-1:
+                        totev=tree.GetEntries()
                     else:
-                        signal=rt.TH2I('sig_pic_run'+str(run_count)+'_ev'+str(entry), '', opt.x_pix, 0, opt.x_pix-1, opt.y_pix, 0, opt.y_pix-1) 
-                        tot_ph_G3=0
-                        for ihit in range(0,tree.numhits):
-                            ## here swapping X with Z beacuse in geant the drift axis is X
-                            S2D = ph_smearing2D(tree.z_hits[ihit],tree.y_hits[ihit],tree.x_hits[ihit],tree.energyDep_hits[ihit],opt)
+                        
+                        if opt.events<=tree.GetEntries():
+                            totev=opt.events
+                        else:
+                            totev=tree.GetEntries()
+                        
+
+        
+                    for entry in range(0, totev): #RUNNING ON ENTRIES
+                        tree.GetEntry(entry)
+                        eventnumber[0] = tree.eventnumber
+                        #FIXME
+                        particle_type[0] = 0
+                        energy_ini[0] = tree.ekin_particle[0]*1000
+                        phi_ini[0] = -999.
+                        theta_ini[0] = -999.
+                        phi_ini[0] = np.arctan2( (tree.y_hits[1]-tree.y_hits[0]),(tree.z_hits[1]-tree.z_hits[0]) )
+                        theta_ini[0] = np.arccos( (tree.x_hits[1]-tree.x_hits[0]) / np.sqrt( np.power((tree.x_hits[1]-tree.x_hits[0]),2) + np.power((tree.y_hits[1]-tree.y_hits[0]),2) + np.power((tree.z_hits[1]-tree.z_hits[0]),2)) )
+                        outtree.Fill()
+                        final_image=rt.TH2I('pic_run'+str(run_count)+'_ev'+str(entry), '', opt.x_pix, 0, opt.x_pix-1, opt.y_pix, 0, opt.y_pix-1) #smeared track with background
+
+
+                        
+                        ## with saturation
+                        if (opt.saturation):
+                            histname = "histo_cloud_pic_"+str(run_count)+"_ev"+str(int(entry)) 
+                            histo_cloud = rt.TH3I(histname,"",opt.x_pix,0,opt.x_pix-1,opt.y_pix,0,opt.y_pix-1,zbins,0,zbins)
+                            #print("created histo_cloud")
+                            tot_el_G2 = 0
+                            for ihit in range(0,tree.numhits):
+                                #print("Processing hit %d of %d"%(ihit,tree.numhits))
+
+                                ## here swapping X with Z beacuse in geant the drift axis is X
+                                S3D = cloud_smearing3D(tree.z_hits[ihit],tree.y_hits[ihit],tree.x_hits[ihit],tree.energyDep_hits[ihit],opt)
+
+                                for j in range(0, len(S3D[0])):
+                                    histo_cloud.Fill((0.5*opt.x_dim+S3D[0][j])*opt.x_pix/opt.x_dim, (0.5*opt.y_dim+S3D[1][j])*opt.y_pix/opt.y_dim, (0.5*histo_cloud.GetNbinsZ()*opt.z_vox_dim+S3D[2][j])/opt.z_vox_dim ) 
+                                    tot_el_G2+=1
+                                    
+                            #tot_el_G2 = histo_cloud.Integral()
+                        
+                            # 2d map of photons applying saturation effect
+                            result_GEM3 = Nph_saturation(histo_cloud,opt)
+                            array2d_Nph = result_GEM3[1]
+                            #tot_ph_G3 = result_GEM3[0] 
+                            tot_ph_G3 = np.sum(array2d_Nph)
+
+                            #print("tot num of sensor counts after GEM3 including saturation: %d"%(tot_ph_G3))
+                            #print("tot num of sensor counts after GEM3 without saturation: %d"%(opt.A*tot_el_G2*GEM3_gain* omega * opt.photons_per_el * opt.counts_per_photon))
+                            #print("Gain GEM3 = %f   Gain GEM3 saturated = %f"%(GEM3_gain, tot_ph_G3/(opt.A * tot_el_G2*omega * opt.photons_per_el * opt.counts_per_photon) ))   
+
+                        ## no saturation
+                        else:
+                            signal=rt.TH2I('sig_pic_run'+str(run_count)+'_ev'+str(entry), '', opt.x_pix, 0, opt.x_pix-1, opt.y_pix, 0, opt.y_pix-1) 
+                            tot_ph_G3=0
+                            for ihit in range(0,tree.numhits):
+                                ## here swapping X with Z beacuse in geant the drift axis is X
+                                S2D = ph_smearing2D(tree.z_hits[ihit],tree.y_hits[ihit],tree.x_hits[ihit],tree.energyDep_hits[ihit],opt)
+                                
+                                for t in range(0, len(S2D[0])):
+                                    tot_ph_G3+=1
+
+                                    signal.Fill((0.5*opt.x_dim+S2D[0][t])*opt.x_pix/opt.x_dim, (0.5*opt.y_dim+S2D[1][t])*opt.y_pix/opt.y_dim ) 
+                            array2d_Nph=rn.hist2array(signal)
+                            array2d_Nph = array2d_Nph 
+                            #print("tot num of sensor counts after GEM3 without saturation: %d"%(tot_ph_G3))
+
+
+                        background=AddBckg(opt,entry)
+                        total=array2d_Nph+background
+
+                        final_image=rn.array2hist(total, final_image)
+                        outfile.cd()
+                        final_image.Write()            
+
+                    outfile.cd('event_info') 
+                    outtree.Write()
+                    print('COMPLETED RUN %d'%(run_count))
+                    run_count+=1
+                    #outfile.Close()
+
+            if opt.rootfiles==False:    
+                # code to be used with input txt files from SRIM
+                if infile.endswith('.txt'):    #KEEPING part.txt FILES ONLY NB: one single file with a specific name for the moment. there are other .txt files in the folder...this has to be fixed...
+
+                    textfile=open(opt.infolder+"/"+infile, "r")
+                    print("Opening file : %s" %infile )
+
+                    infilename=infile[:-4]    
+                    outfile=rt.TFile('%s/histograms_Run%05d.root' % (opt.outfolder,run_count), 'RECREATE') #OUTPUT NAME
+                    outfile.mkdir('event_info')
+                    SaveValues(params, outfile) ## SAVE PARAMETERS OF THE RUN
+                    outtree = rt.TTree("info_tree", "info_tree")
+                    outtree.Branch("eventnumber", eventnumber, "eventnumber/I")
+                    outtree.Branch("particle_type", particle_type, "particle_type/I")
+                    outtree.Branch("energy_ini", energy_ini, "energy_ini/F")
+                    outtree.Branch("theta_ini", theta_ini, "theta_ini/F")
+                    outtree.Branch("phi_ini", phi_ini, "phi_ini/F")
+
+                    final_imgs=list();
+                    zvec=list(); yvec=list(); xvec=list(); evec=list(); phiini=list(); thetaini=list(); eini=list();
+                    zvec*=0; yvec*=0; xvec*=0; evec*=0; phiini*=0; thetaini*=0; eini*=0;
+                    lastentry=0
+                    nhits=0
+                    iline=0
+                    sumene = 0
+                    sumeneQF = 0
+                    content = textfile.readlines() #READ IN TXT FILE
+                    tot_el_G2=0
+                    tot_ph_G3=0
+                    zbins = int(opt.zcloud/opt.z_vox_dim)
+
+                    histname = "histo_cloud"+str(run_count)+"_pic_0"
+                    histo_cloud = rt.TH3I(histname,"",opt.x_pix,0,opt.x_pix-1,opt.y_pix,0,opt.y_pix-1,zbins,0,zbins)
+                    signal=rt.TH2I('sig_run'+str(run_count)+'_ev0', '', opt.x_pix, 0, opt.x_pix-1, opt.y_pix, 0, opt.y_pix-1) #smeared track with background
+                    final_image=rt.TH2I('pic_run'+str(run_count)+'_ev0', '', opt.x_pix, 0, opt.x_pix-1, opt.y_pix, 0, opt.y_pix-1) #smeared track with background
+                    
+                    array2d_Nph = np.zeros((opt.x_pix,opt.y_pix))
+                    
+                    
+                    for nlines,line in enumerate(content):           #LOOP OVER LINES (HITS)
+                        #print(line)
+                        
+                        if lastentry>=opt.events and opt.events!=-1:
+                            break  #EXIT FROM LOOP OVER LINES
+                        
+                        myvars=line.split()
+                        #print(myvars)
+                        entry=int(myvars[0])-1
+                        sumene += float(myvars[5])
+                        sumeneQF += float(myvars[6])
+                        x_hit = float(myvars[2])
+                        y_hit = float(myvars[3])
+                        z_hit = float(myvars[4])
+                        energyDep_hit = float(myvars[6]) ##INCLUDE QF
+                        nhits=int(myvars[1])
+                        zvec.append(float(myvars[4]))
+                        yvec.append(float(myvars[3]))
+                        xvec.append(float(myvars[2]))
+                        evec.append(float(myvars[6]))
+                        if (len(myvars)>7):
+                            thetaini.append(float(myvars[7]))
+                            phiini.append(float(myvars[8]))
+                            eini.append(float(myvars[9]))
+
+
+                        if (np.isnan(x_hit) or np.isnan(y_hit) or np.isnan(z_hit)):
+                            continue ## SKIP LINE WITH NAN VALUES
+
+                        # SATURATION SIM
+                        if(opt.saturation):
+                            S3D = cloud_smearing3D(x_hit,y_hit,z_hit,energyDep_hit,opt)
+
+                            for j in range(0, len(S3D[0])): #LOOP OVER ELECTRONS AFTER GEM2 
+
+                                histo_cloud.Fill((0.5*opt.x_dim+S3D[0][j])*opt.x_pix/opt.x_dim, (0.5*opt.y_dim+S3D[1][j])*opt.y_pix/opt.y_dim, (0.5*opt.zcloud+S3D[2][j])*zbins/opt.zcloud )
+                                tot_el_G2+=1
+                    
+                                if (entry!=lastentry or nlines==len(content)-1 ): #NEW EVENT FOUND (OR LAST LINE IN THE FILE) - STORE INFORMATIONS ON PREVIOUS ONE
+                                    #print("tot_el_G2 = %d"%tot_el_G2)
+                    
+                                    # 2d map of photons applying saturation effect
+                                    result_GEM3 = Nph_saturation(histo_cloud,opt)
+                                    array2d_Nph = result_GEM3[1]
+                                    tot_ph_G3 = result_GEM3[0] #np.sum(array2d_Nph)
+                    
+                                    #print("tot num of sensor counts after GEM3 including saturation: %d"%(tot_ph_G3))
+                                    #print("tot num of sensor counts after GEM3 without saturation: %d"%(opt.A*tot_el_G2*GEM3_gain* omega * opt.photons_per_el * opt.counts_per_photon))
+                                    #print("Gain GEM3 = %f   Gain GEM3 saturated = %f"%(GEM3_gain, tot_ph_G3/(tot_el_G2*omega * opt.photons_per_el * opt.counts_per_photon) ))
+                    
+                                    # add background
+                                    background=AddBckg(opt,entry)
+                                    total=array2d_Nph+background
+                                    rn.array2hist(total, final_image)
+                                    
+                                    # write output file
+                                    outfile.cd()
+                                    final_image.Write()
+                                    nphot = final_image.Integral()
+                                    
+                                    # fill info_tree
+                                    eventnumber[0] = lastentry
+                                    #FIXME (particle type NR = 1, could be changed with PDG number)
+                                    particle_type[0] = 1
+                                    if len(myvars)>7:
+                                        phi_ini[0]    = phiini[entry]
+                                        theta_ini[0]  = thetaini[entry]
+                                        energy_ini[0] = eini[entry]
+                                    else:
+                                        phi_ini[0]    = -999  
+                                        theta_ini[0]  = -999 
+                                        energy_ini[0] = -999 
+
+                                    outtree.Fill()
+                                    
+                    
+                                    
+                                    print("lastentry = %d"%lastentry)
+                                    print("tot ion energy = "+str(sumene))
+                                    print("ion energy * QF = "+str(sumeneQF))
+                                    print("nphot = "+str(nphot))
+                   
+                                    # create empty histograms for new track
+                                    histname = "histo_cloud"+str(run_count)+"_pic_"+str(int(entry))
+                                    histo_cloud = rt.TH3I(histname,"",opt.x_pix,0,opt.x_pix-1,opt.y_pix,0,opt.y_pix-1,zbins,0,zbins)
+                                    final_image=rt.TH2I('pic_run'+str(run_count)+'_ev'+str(entry), '', opt.x_pix, 0, opt.x_pix-1, opt.y_pix, 0, opt.y_pix-1) #smeared track sig+bckg (if bckg ON)
+                    
+                                    
+                                    zvec*=0; yvec*=0; xvec*=0; evec*=0; phiini*=0; thetaini*=0; eini*=0; #RESET LISTS
+                                    sumene = 0.
+                                    sumeneQF = 0.
+                                    tot_el_G2 = 0
+                                    lastentry=entry #END OF THE EVENT
+                                    if lastentry>=opt.events and opt.events!=-1:
+                                        break ##EXIT FROM LOOP OVER GEM2 ELECTRONS
+
+                                ##CLOSE IF NEW EVENT/EOF    
+
+                            ## CLOSE LOOP OVER GEM2 ELECTRONS
+                        
+                        # NO SATURATION 
+                        else:
                             
+                            S2D = ph_smearing2D(x_hit,y_hit,z_hit,energyDep_hit,opt)
+                                
                             for t in range(0, len(S2D[0])):
                                 tot_ph_G3+=1
 
                                 signal.Fill((0.5*opt.x_dim+S2D[0][t])*opt.x_pix/opt.x_dim, (0.5*opt.y_dim+S2D[1][t])*opt.y_pix/opt.y_dim ) 
-                        array2d_Nph=rn.hist2array(signal)
-                        array2d_Nph = array2d_Nph 
-                        #print("tot num of sensor counts after GEM3 without saturation: %d"%(tot_ph_G3))
-
-
-                    background=AddBckg(opt,entry)
-                    total=array2d_Nph+background
-
-                    final_image=rn.array2hist(total, final_image)
-                    outfile.cd()
-                    final_image.Write()            
-
-                outfile.cd('event_info') 
-                outtree.Write()
-                print('COMPLETED RUN %d'%(run_count))
-                run_count+=1
-                #outfile.Close()
-
-        if opt.rootfiles==False:    
-            # code to be used with input txt files from SRIM
-            if infile.endswith('.txt'):    #KEEPING part.txt FILES ONLY NB: one single file with a specific name for the moment. there are other .txt files in the folder...this has to be fixed...
-
-                textfile=open(opt.infolder+"/"+infile, "r")
-                print("Opening file : %s" %infile )
-
-                infilename=infile[:-4]    
-                outfile=rt.TFile('%s/histograms_Run%05d.root' % (opt.outfolder,run_count), 'RECREATE') #OUTPUT NAME
-                outfile.mkdir('event_info')
-                SaveValues(params, outfile) ## SAVE PARAMETERS OF THE RUN
-                outtree = rt.TTree("info_tree", "info_tree")
-                outtree.Branch("eventnumber", eventnumber, "eventnumber/I")
-                outtree.Branch("particle_type", particle_type, "particle_type/I")
-                outtree.Branch("energy_ini", energy_ini, "energy_ini/F")
-                outtree.Branch("theta_ini", theta_ini, "theta_ini/F")
-                outtree.Branch("phi_ini", phi_ini, "phi_ini/F")
-
-                final_imgs=list();
-                zvec=list(); yvec=list(); xvec=list(); evec=list(); phiini=list(); thetaini=list(); eini=list();
-                zvec*=0; yvec*=0; xvec*=0; evec*=0; phiini*=0; thetaini*=0; eini*=0;
-                lastentry=0
-                nhits=0
-                iline=0
-                sumene = 0
-                sumeneQF = 0
-                content = textfile.readlines() #READ IN TXT FILE
-                tot_el_G2=0
-                tot_ph_G3=0
-                zbins = int(opt.zcloud/opt.z_vox_dim)
-
-                histname = "histo_cloud"+str(run_count)+"_pic_0"
-                histo_cloud = rt.TH3I(histname,"",opt.x_pix,0,opt.x_pix-1,opt.y_pix,0,opt.y_pix-1,zbins,0,zbins)
-                signal=rt.TH2I('sig_run'+str(run_count)+'_ev0', '', opt.x_pix, 0, opt.x_pix-1, opt.y_pix, 0, opt.y_pix-1) #smeared track with background
-                final_image=rt.TH2I('pic_run'+str(run_count)+'_ev0', '', opt.x_pix, 0, opt.x_pix-1, opt.y_pix, 0, opt.y_pix-1) #smeared track with background
-                
-                array2d_Nph = np.zeros((opt.x_pix,opt.y_pix))
-                
-                
-                for nlines,line in enumerate(content):           #LOOP OVER LINES (HITS)
-                    #print(line)
+                                
+                                if (entry!=lastentry or nlines==len(content)-1 ): #NEW EVENT FOUND (OR LAST LINE IN THE FILE) - STORE INFORMATIONS ON PREVIOUS ONE
                     
-                    if lastentry>=opt.events and opt.events!=-1:
-                        break  #EXIT FROM LOOP OVER LINES
+                                    # 2d map of photons applying saturation effect
+                                    array2d_Nph=rn.hist2array(signal)
+                                    #print("tot num of sensor counts after GEM3 without saturation: %d"%(tot_ph_G3))
                     
-                    myvars=line.split()
-                    #print(myvars)
-                    entry=int(myvars[0])-1
-                    sumene += float(myvars[5])
-                    sumeneQF += float(myvars[6])
-                    x_hit = float(myvars[2])
-                    y_hit = float(myvars[3])
-                    z_hit = float(myvars[4])
-                    energyDep_hit = float(myvars[6]) ##INCLUDE QF
-                    nhits=int(myvars[1])
-                    zvec.append(float(myvars[4]))
-                    yvec.append(float(myvars[3]))
-                    xvec.append(float(myvars[2]))
-                    evec.append(float(myvars[6]))
-                    if (len(myvars)>7):
-                        thetaini.append(float(myvars[7]))
-                        phiini.append(float(myvars[8]))
-                        eini.append(float(myvars[9]))
+                                    background=AddBckg(opt,entry)
+                                    total=array2d_Nph+background
+                                    
+                                    rn.array2hist(total,final_image)
+                                    nphot = final_image.Integral()
+
+                                    # write output file
+                                    outfile.cd()
+                                    final_image.Write()
+                                    nphot = final_image.Integral()
+                                    
+                                    # fill info_tree
+                                    eventnumber[0] = lastentry
+                                    #FIXME
+                                    particle_type[0] = 1
+                                    if len(myvars)>7:
+                                        phi_ini[0]    = phiini[entry] 
+                                        theta_ini[0]  = thetaini[entry]
+                                        energy_ini[0] = eini[entry]
+                                    else:
+                                        phi_ini[0]    = -999  
+                                        theta_ini[0]  = -999 
+                                        energy_ini[0] = -999 
+
+                                    outtree.Fill()
+                                    
+                                    print("lastentry = %d"%lastentry)
+                                    print("tot ion energy = "+str(sumene))
+                                    print("ion energy * QF = "+str(sumeneQF))
+                                    print("nphot = "+str(nphot))
+                                    
+                     
+                                    # create empty histograms for new track
+                                    signal=rt.TH2I('sig_run'+str(run_count)+'_ev'+str(entry), '', opt.x_pix, 0, opt.x_pix-1, opt.y_pix, 0, opt.y_pix-1) #smeared track with background
+                                    final_image=rt.TH2I('pic_run'+str(run_count)+'_ev'+str(entry), '', opt.x_pix, 0, opt.x_pix-1, opt.y_pix, 0, opt.y_pix-1) #smeared track with background
+                                    
+                                    
+                                    zvec*=0; yvec*=0; xvec*=0; evec*=0; phiini*=0; thetaini*=0; eini*=0; #RESET LISTS
+                                    sumene = 0.
+                                    sumeneQF = 0.
+                                    tot_ph_G3 = 0
+                                    
+                                    lastentry=entry #END OF THE EVENT
+                                    if lastentry>=opt.events and opt.events!=-1:
+                                        break ##EXIT FROM LOOP OVER GEM3 PHOTONS
+
+                                ##CLOSE IF NEW EVENT/EOF    
+
+                            ## CLOSE LOOP OVER GEM3 PHOTONS
 
 
-                    if (np.isnan(x_hit) or np.isnan(y_hit) or np.isnan(z_hit)):
-                        continue ## SKIP LINE WITH NAN VALUES
-
-                    # SATURATION SIM
-                    if(opt.saturation):
-                        S3D = cloud_smearing3D(x_hit,y_hit,z_hit,energyDep_hit,opt)
-
-                        for j in range(0, len(S3D[0])): #LOOP OVER ELECTRONS AFTER GEM2 
-
-                            histo_cloud.Fill((0.5*opt.x_dim+S3D[0][j])*opt.x_pix/opt.x_dim, (0.5*opt.y_dim+S3D[1][j])*opt.y_pix/opt.y_dim, (0.5*opt.zcloud+S3D[2][j])*zbins/opt.zcloud )
-                            tot_el_G2+=1
-                
-                            if (entry!=lastentry or nlines==len(content)-1 ): #NEW EVENT FOUND (OR LAST LINE IN THE FILE) - STORE INFORMATIONS ON PREVIOUS ONE
-                                #print("tot_el_G2 = %d"%tot_el_G2)
-                
-                                # 2d map of photons applying saturation effect
-                                result_GEM3 = Nph_saturation(histo_cloud,opt)
-                                array2d_Nph = result_GEM3[1]
-                                tot_ph_G3 = result_GEM3[0] #np.sum(array2d_Nph)
-                
-                                #print("tot num of sensor counts after GEM3 including saturation: %d"%(tot_ph_G3))
-                                #print("tot num of sensor counts after GEM3 without saturation: %d"%(opt.A*tot_el_G2*GEM3_gain* omega * opt.photons_per_el * opt.counts_per_photon))
-                                #print("Gain GEM3 = %f   Gain GEM3 saturated = %f"%(GEM3_gain, tot_ph_G3/(tot_el_G2*omega * opt.photons_per_el * opt.counts_per_photon) ))
-                
-                                # add background
-                                background=AddBckg(opt,entry)
-                                total=array2d_Nph+background
-                                rn.array2hist(total, final_image)
-                                
-                                # write output file
-                                outfile.cd()
-                                final_image.Write()
-                                nphot = final_image.Integral()
-                                
-                                # fill info_tree
-                                eventnumber[0] = lastentry
-                                #FIXME (particle type NR = 1, could be changed with PDG number)
-                                particle_type[0] = 1
-                                if len(myvars)>7:
-                                    phi_ini[0]    = phiini[entry]
-                                    theta_ini[0]  = thetaini[entry]
-                                    energy_ini[0] = eini[entry]
-                                else:
-                                    phi_ini[0]    = -999  
-                                    theta_ini[0]  = -999 
-                                    energy_ini[0] = -999 
-
-                                outtree.Fill()
-                                
-                
-                                
-                                print("lastentry = %d"%lastentry)
-                                print("tot ion energy = "+str(sumene))
-                                print("ion energy * QF = "+str(sumeneQF))
-                                print("nphot = "+str(nphot))
-               
-                                # create empty histograms for new track
-                                histname = "histo_cloud"+str(run_count)+"_pic_"+str(int(entry))
-                                histo_cloud = rt.TH3I(histname,"",opt.x_pix,0,opt.x_pix-1,opt.y_pix,0,opt.y_pix-1,zbins,0,zbins)
-                                final_image=rt.TH2I('pic_run'+str(run_count)+'_ev'+str(entry), '', opt.x_pix, 0, opt.x_pix-1, opt.y_pix, 0, opt.y_pix-1) #smeared track sig+bckg (if bckg ON)
-                
-                                
-                                zvec*=0; yvec*=0; xvec*=0; evec*=0; phiini*=0; thetaini*=0; eini*=0; #RESET LISTS
-                                sumene = 0.
-                                sumeneQF = 0.
-                                tot_el_G2 = 0
-                                lastentry=entry #END OF THE EVENT
-                                if lastentry>=opt.events and opt.events!=-1:
-                                    break ##EXIT FROM LOOP OVER GEM2 ELECTRONS
-
-                            ##CLOSE IF NEW EVENT/EOF    
-
-                        ## CLOSE LOOP OVER GEM2 ELECTRONS
-                    
-                    # NO SATURATION 
-                    else:
-                        
-                        S2D = ph_smearing2D(x_hit,y_hit,z_hit,energyDep_hit,opt)
-                            
-                        for t in range(0, len(S2D[0])):
-                            tot_ph_G3+=1
-
-                            signal.Fill((0.5*opt.x_dim+S2D[0][t])*opt.x_pix/opt.x_dim, (0.5*opt.y_dim+S2D[1][t])*opt.y_pix/opt.y_dim ) 
-                            
-                            if (entry!=lastentry or nlines==len(content)-1 ): #NEW EVENT FOUND (OR LAST LINE IN THE FILE) - STORE INFORMATIONS ON PREVIOUS ONE
-                
-                                # 2d map of photons applying saturation effect
-                                array2d_Nph=rn.hist2array(signal)
-                                #print("tot num of sensor counts after GEM3 without saturation: %d"%(tot_ph_G3))
-                
-                                background=AddBckg(opt,entry)
-                                total=array2d_Nph+background
-                                
-                                rn.array2hist(total,final_image)
-                                nphot = final_image.Integral()
-
-                                # write output file
-                                outfile.cd()
-                                final_image.Write()
-                                nphot = final_image.Integral()
-                                
-                                # fill info_tree
-                                eventnumber[0] = lastentry
-                                #FIXME
-                                particle_type[0] = 1
-                                if len(myvars)>7:
-                                    phi_ini[0]    = phiini[entry] 
-                                    theta_ini[0]  = thetaini[entry]
-                                    energy_ini[0] = eini[entry]
-                                else:
-                                    phi_ini[0]    = -999  
-                                    theta_ini[0]  = -999 
-                                    energy_ini[0] = -999 
-
-                                outtree.Fill()
-                                
-                                print("lastentry = %d"%lastentry)
-                                print("tot ion energy = "+str(sumene))
-                                print("ion energy * QF = "+str(sumeneQF))
-                                print("nphot = "+str(nphot))
-                                
-                 
-                                # create empty histograms for new track
-                                signal=rt.TH2I('sig_run'+str(run_count)+'_ev'+str(entry), '', opt.x_pix, 0, opt.x_pix-1, opt.y_pix, 0, opt.y_pix-1) #smeared track with background
-                                final_image=rt.TH2I('pic_run'+str(run_count)+'_ev'+str(entry), '', opt.x_pix, 0, opt.x_pix-1, opt.y_pix, 0, opt.y_pix-1) #smeared track with background
-                                
-                                
-                                zvec*=0; yvec*=0; xvec*=0; evec*=0; phiini*=0; thetaini*=0; eini*=0; #RESET LISTS
-                                sumene = 0.
-                                sumeneQF = 0.
-                                tot_ph_G3 = 0
-                                
-                                lastentry=entry #END OF THE EVENT
-                                if lastentry>=opt.events and opt.events!=-1:
-                                    break ##EXIT FROM LOOP OVER GEM3 PHOTONS
-
-                            ##CLOSE IF NEW EVENT/EOF    
-
-                        ## CLOSE LOOP OVER GEM3 PHOTONS
+                        ## LOOP OVER LINES (HITS)    
+                        iline+=1
+                        #if iline==1:
+                        #    print("line: "+str(iline)+"  QF avg = "+str(float(myvars[6])/float(myvars[5])))         
+                                 
+                    ## CLOSE LOOP OVER LINES (HITS)    
+                   
+                    ## CONTINUE LOOP OVER TXT FILES
+                    print('COMPLETED RUN %d'%(run_count))
+                    run_count+=1
+                    outfile.cd('event_info') 
+                    outtree.Write()
+                    #outfile.Close()
 
 
-                    ## LOOP OVER LINES (HITS)    
-                    iline+=1
-                    #if iline==1:
-                    #    print("line: "+str(iline)+"  QF avg = "+str(float(myvars[6])/float(myvars[5])))         
-                             
-                ## CLOSE LOOP OVER LINES (HITS)    
-               
-                ## CONTINUE LOOP OVER TXT FILES
-                print('COMPLETED RUN %d'%(run_count))
-                run_count+=1
-                outfile.cd('event_info') 
-                outtree.Write()
-                #outfile.Close()
-
-
-    t1=time.time()
-    if opt.donotremove == False:
-        sw.swift_rm_root_file(opt.tmpname)
-    print('\n')
-    print('Generation took %d seconds'%(t1-t0))
+        t1=time.time()
+        if opt.donotremove == False:
+            sw.swift_rm_root_file(opt.tmpname)
+        print('\n')
+        print('Generation took %d seconds'%(t1-t0))
 

--- a/MC_data_new.py
+++ b/MC_data_new.py
@@ -221,7 +221,7 @@ if __name__ == "__main__":
         t0=time.time()
        
         # UNCOMMENT THIS LINE IF YOU WANT TO STUDY THE SIMULATION WITH THE SAME STATISTICAL FLUCTUATIONS (SAME SEED): IT IS USEFUL FOR DEBUGGING
-        np.random.seed(seed=0)
+        #np.random.seed(seed=0)
 
 
         eventnumber = np.array([-999], dtype="int")

--- a/MC_data_new.py
+++ b/MC_data_new.py
@@ -181,7 +181,7 @@ if __name__ == "__main__":
     t0=time.time()
    
     # UNCOMMENT THIS LINE IF YOU WANT TO STUDY THE SIMULATION WITH THE SAME STATISTICAL FLUCTUATIONS (SAME SEED): IT IS USEFUL FOR DEBUGGING
-    #np.random.seed(seed=0)
+    np.random.seed(seed=0)
 
 
     eventnumber = np.array([-999], dtype="int")
@@ -244,15 +244,13 @@ if __name__ == "__main__":
                     outtree.Fill()
                     final_image=rt.TH2I('pic_run'+str(run_count)+'_ev'+str(entry), '', opt.x_pix, 0, opt.x_pix-1, opt.y_pix, 0, opt.y_pix-1) #smeared track with background
 
-                   
-                    histname = "histo_cloud_pic_"+str(run_count)+"_ev"+str(int(entry)) 
-                    histo_cloud = rt.TH3I(histname,"",opt.x_pix,0,opt.x_pix-1,opt.y_pix,0,opt.y_pix-1,zbins,0,zbins)
-                    signal=rt.TH2I('sig_pic_run'+str(run_count)+'_ev'+str(entry), '', opt.x_pix, 0, opt.x_pix-1, opt.y_pix, 0, opt.y_pix-1) 
 
-                    #print("created histo_cloud")
                     
                     ## with saturation
                     if (opt.saturation):
+                        histname = "histo_cloud_pic_"+str(run_count)+"_ev"+str(int(entry)) 
+                        histo_cloud = rt.TH3I(histname,"",opt.x_pix,0,opt.x_pix-1,opt.y_pix,0,opt.y_pix-1,zbins,0,zbins)
+                        #print("created histo_cloud")
                         tot_el_G2 = 0
                         for ihit in range(0,tree.numhits):
                             #print("Processing hit %d of %d"%(ihit,tree.numhits))
@@ -278,6 +276,7 @@ if __name__ == "__main__":
 
                     ## no saturation
                     else:
+                        signal=rt.TH2I('sig_pic_run'+str(run_count)+'_ev'+str(entry), '', opt.x_pix, 0, opt.x_pix-1, opt.y_pix, 0, opt.y_pix-1) 
                         tot_ph_G3=0
                         for ihit in range(0,tree.numhits):
                             ## here swapping X with Z beacuse in geant the drift axis is X

--- a/MC_data_new.py
+++ b/MC_data_new.py
@@ -208,7 +208,9 @@ if __name__ == "__main__":
                 tree=rootfile.Get('nTuple')            #GETTING NTUPLES
             
                 infilename=infile[:-5]    
-                outfile=rt.TFile('%s/histograms_Run%05d.root' % (opt.outfolder,run_count), 'RECREATE') #OUTPUT NAME
+                #outfile=rt.TFile('%s/histograms_Run%05d.root' % (opt.outfolder,run_count), 'RECREATE') #OUTPUT NAME (only run number)
+                #outfile=rt.TFile('%s/histograms_%s_%d_mm_%d_V.root' % (opt.outfolder, infilename, opt.z_gem-z_ini, opt.GEM1_HV), 'RECREATE') #OUTPUT NAME WITH PARAMETERS INFO
+                outfile=rt.TFile('%s/histograms_%s_%d_mm_%d_V_%s.root' % (opt.outfolder, infilename, opt.z_gem-z_ini, opt.GEM1_HV, time.strftime("%Y%m%d-%H%M%S") ), 'RECREATE') #OUTPUT NAME WITH PARAMETERS INFO AND TIMESTAMP
                 outfile.mkdir('event_info')
                 SaveValues(params, outfile) ## SAVE PARAMETERS OF THE RUN
                 outtree = rt.TTree("info_tree", "info_tree")

--- a/MC_data_new.py
+++ b/MC_data_new.py
@@ -284,7 +284,6 @@ if __name__ == "__main__":
                         phi_ini[0] = np.arctan2( (tree.y_hits[1]-tree.y_hits[0]),(tree.z_hits[1]-tree.z_hits[0]) )
                         theta_ini[0] = np.arccos( (tree.x_hits[1]-tree.x_hits[0]) / np.sqrt( np.power((tree.x_hits[1]-tree.x_hits[0]),2) + np.power((tree.y_hits[1]-tree.y_hits[0]),2) + np.power((tree.z_hits[1]-tree.z_hits[0]),2)) )
                         outtree.Fill()
-                        final_image=rt.TH2I('pic_run'+str(run_count)+'_ev'+str(entry), '', opt.x_pix, 0, opt.x_pix-1, opt.y_pix, 0, opt.y_pix-1) #smeared track with background
 
 
                         
@@ -295,9 +294,6 @@ if __name__ == "__main__":
                             S3D_y=np.array([])
                             S3D_z=np.array([])
 
-                            histname = "histo_cloud_pic_"+str(run_count)+"_ev"+str(int(entry)) 
-                            histo_cloud = rt.TH3I(histname,"",opt.x_pix,0,opt.x_pix-1,opt.y_pix,0,opt.y_pix-1,zbins,0,zbins)
-                            #print("created histo_cloud")
                             for ihit in range(0,tree.numhits):
                                 #print("Processing hit %d of %d"%(ihit,tree.numhits))
 
@@ -317,6 +313,9 @@ if __name__ == "__main__":
                             zmax=2+int(round(max( (0.5*zbins*opt.z_vox_dim+S3D_z)/opt.z_vox_dim))) 
                             zmin=-2+int(round(min( (0.5*zbins*opt.z_vox_dim+S3D_z)/opt.z_vox_dim)))
 
+                            histname = "histo_cloud_pic_"+str(run_count)+"_ev"+str(int(entry)) 
+                            histo_cloud = rt.TH3I(histname,"",opt.x_pix,0,opt.x_pix-1,opt.y_pix,0,opt.y_pix-1,zbins,0,zbins)
+                            #print("created histo_cloud")
                             tot_el_G2 = 0
                             for j in range(0, len(S3D_x)):
                                 histo_cloud.Fill((0.5*opt.x_dim+S3D_x[j])*opt.x_pix/opt.x_dim, (0.5*opt.y_dim+S3D_y[j])*opt.y_pix/opt.y_dim, (0.5*zbins*opt.z_vox_dim+S3D_z[j])/opt.z_vox_dim ) 
@@ -358,6 +357,7 @@ if __name__ == "__main__":
                         background=AddBckg(opt,entry)
                         total=array2d_Nph+background
 
+                        final_image=rt.TH2I('pic_run'+str(run_count)+'_ev'+str(entry), '', opt.x_pix, 0, opt.x_pix-1, opt.y_pix, 0, opt.y_pix-1) #smeared track with background
                         final_image=rn.array2hist(total, final_image)
                         outfile.cd()
                         final_image.Write()            

--- a/MC_data_new.py
+++ b/MC_data_new.py
@@ -306,12 +306,12 @@ if __name__ == "__main__":
                                     
                             #tot_el_G2 = histo_cloud.Integral()
                             
-                            histo_cloud_array=rn.hist2array(histo_cloud)               # CONVERT ROOT HISTO TO NUMPY ARRAY
+                            #histo_cloud_array=rn.hist2array(histo_cloud)               # CONVERT ROOT HISTO TO NUMPY ARRAY
 
 
                             # 2d map of photons applying saturation effect
-                            #result_GEM3 = Nph_saturation(histo_cloud,opt)             # SLOW SATURATION WITH 3 FOR LOOP
-                            result_GEM3 = Nph_saturation_array(histo_cloud_array,opt)  # FAST SATURATION WITH NUMPY
+                            result_GEM3 = Nph_saturation(histo_cloud,opt)             # SLOW SATURATION WITH 3 FOR LOOP
+                            #result_GEM3 = Nph_saturation_array(histo_cloud_array,opt)  # FAST SATURATION WITH NUMPY
                             array2d_Nph = result_GEM3[1]
                             #tot_ph_G3 = result_GEM3[0] 
                             tot_ph_G3 = np.sum(array2d_Nph)

--- a/MC_data_new.py
+++ b/MC_data_new.py
@@ -187,6 +187,7 @@ if __name__ == "__main__":
             params_with_list[k]=v
    
     # NOW SCAN OVER MULTIPLE PARAMETERS
+    run_count=1
     for scan_idx in range(0,scan_length):
         params={}
         for k, v in params_with_list.items():
@@ -217,7 +218,6 @@ if __name__ == "__main__":
         #print(omega)
 
     #### CODE EXECUTION ####
-        run_count=1
         t0=time.time()
        
         # UNCOMMENT THIS LINE IF YOU WANT TO STUDY THE SIMULATION WITH THE SAME STATISTICAL FLUCTUATIONS (SAME SEED): IT IS USEFUL FOR DEBUGGING

--- a/MC_data_new.py
+++ b/MC_data_new.py
@@ -179,7 +179,11 @@ if __name__ == "__main__":
 #### CODE EXECUTION ####
     run_count=1
     t0=time.time()
-    
+   
+    # UNCOMMENT THIS LINE IF YOU WANT TO STUDY THE SIMULATION WITH THE SAME STATISTICAL FLUCTUATIONS (SAME SEED): IT IS USEFUL FOR DEBUGGING
+    #np.random.seed(seed=0)
+
+
     eventnumber = np.array([-999], dtype="int")
     particle_type = np.array([-999], dtype="int")
     energy_ini = np.array([-999], dtype="float32")

--- a/MC_data_new.py
+++ b/MC_data_new.py
@@ -82,6 +82,22 @@ def Nph_saturation(histo_cloud,options):
     return Nph_tot, Nph_array
 
 
+    
+def Nph_saturation_array(histo_cloud,options):
+    Nph_array = np.zeros((histo_cloud.shape[0],histo_cloud.shape[1]))
+    Nph_tot = 0
+
+    nel_in=histo_cloud
+    hin=(nel_in  * options.A * GEM3_gain)/(1 + options.beta * GEM3_gain  * nel_in) 
+    hout=np.sum(hin,axis=(2))
+    nmean_ph= hout * omega * options.photons_per_el * options.counts_per_photon     # mean total number of photons
+    poisson_distr = lambda x: poisson(x).rvs()
+    n_ph=poisson_distr(nmean_ph) 
+    Nph_array=n_ph
+    Nph_tot=np.sum(n_ph)
+            
+    return Nph_tot, Nph_array
+
 
 def AddBckg(options, i):
     bckg_array=np.zeros((options.x_pix,options.y_pix))
@@ -205,7 +221,7 @@ if __name__ == "__main__":
         t0=time.time()
        
         # UNCOMMENT THIS LINE IF YOU WANT TO STUDY THE SIMULATION WITH THE SAME STATISTICAL FLUCTUATIONS (SAME SEED): IT IS USEFUL FOR DEBUGGING
-        #np.random.seed(seed=0)
+        np.random.seed(seed=0)
 
 
         eventnumber = np.array([-999], dtype="int")
@@ -289,9 +305,13 @@ if __name__ == "__main__":
                                     tot_el_G2+=1
                                     
                             #tot_el_G2 = histo_cloud.Integral()
-                        
+                            
+                            histo_cloud_array=rn.hist2array(histo_cloud)               # CONVERT ROOT HISTO TO NUMPY ARRAY
+
+
                             # 2d map of photons applying saturation effect
-                            result_GEM3 = Nph_saturation(histo_cloud,opt)
+                            #result_GEM3 = Nph_saturation(histo_cloud,opt)             # SLOW SATURATION WITH 3 FOR LOOP
+                            result_GEM3 = Nph_saturation_array(histo_cloud_array,opt)  # FAST SATURATION WITH NUMPY
                             array2d_Nph = result_GEM3[1]
                             #tot_ph_G3 = result_GEM3[0] 
                             tot_ph_G3 = np.sum(array2d_Nph)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 MC_data_gen.py
 ===============
 This simple script applies both the smearing due to diffusion and the electronic noise background to a MC sample track (GEANT4 output).
-To run, the script need to be in the same location where ConfigFile.txt is. This file contains all the parameters that can be manually set as the user prefers.
+To run, the script need to be in the same location where ConfigFile.txt is.
+
+This file contains all the parameters that can be manually set as the user prefers. For each parameter you can either set a single value or a list of values. This allows you to easily run the simulation multiple times with differet paramters.
+Each list represents the sequence of paramters the simulation will use for each run. Single-value paramters are interpreted as fixed values (the same for each run).
+You can have as many lists as you want, as long as the length is the same. This can be useful for a HV-scan where 3 paramters (GEM1_HV, GEM2_HV and GEM3_HV) change for each run.
+
 The output file is a `.root` file containing all the TH2F histograms generated.
 
 USAGE

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ MC_data_gen.py
 This simple script applies both the smearing due to diffusion and the electronic noise background to a MC sample track (GEANT4 output).
 To run, the script need to be in the same location where ConfigFile.txt is.
 
-This file contains all the parameters that can be manually set as the user prefers. For each parameter you can either set a single value or a list of values. This allows you to easily run the simulation multiple times with differet paramters.
+ConfigFile.txt contains all the parameters that can be manually set as the user prefers. For each parameter you can either set a single value or a list of values. This allows you to easily run the simulation multiple times with differet paramters.
 Each list represents the sequence of paramters the simulation will use for each run. Single-value paramters are interpreted as fixed values (the same for each run).
 You can have as many lists as you want, as long as the length is the same. This can be useful for a HV-scan where 3 paramters (GEM1_HV, GEM2_HV and GEM3_HV) change for each run.
 
@@ -55,8 +55,19 @@ gStyle->SetOptStat(0)
 ```
 and to set properly the z-axis scale once the TH2F has been written with `COLZ` option.
 
+
+Suggestions for debugging and contributing
+------------
+If you have made minor changes to the code, and the physical model has not changed, the output should be the same (except for statistical fluctuations). 
+Once you have set the same seed for probability distributions, you can use the script compare_digitizations.py to easily compare the output of two simulations. For instance: 
+
+```Javascript
+python3 compare_digitizations.py output1.root output2.root
+```
+
 Work in progress
 ------------
 + Add an option in `ConfigFile.txt` to choose between different detectors and geometries, in order to simulate other setups without manually changing the parameters
 + Parallelize background generation to make the script run faster
-
++ Speed up the simulation with saturation effect, maybe with a parametrization
++ Find a way to apply saturation effect to non-spot tracks

--- a/compare_digitizations.py
+++ b/compare_digitizations.py
@@ -1,0 +1,57 @@
+#!/usr/bin/python
+import numpy as np
+import sys
+import ROOT as rt
+
+# This script compares the ouput of two different digitization. It can be useful for debugging, or to do a simple check after the code has been changed.
+
+# The script takes in input two root files with the same number of digitized images (output of MC_data_new.py) and compute the difference bin by bin of each image.
+
+# Note: in order to compare two root files, the same seed in the probabilità distribution must be set. In numpy, for instance:       np.random.seed(seed=0)
+
+filename1=str(sys.argv[1])
+filename2=str(sys.argv[2])
+
+rootFile1 = rt.TFile.Open(filename1)
+rootFile2 = rt.TFile.Open(filename2)
+
+num_of_events1=rootFile1.Get("event_info/info_tree").GetEntries()
+num_of_events2=rootFile2.Get("event_info/info_tree").GetEntries()
+
+
+if num_of_events1 != num_of_events2:
+    print("\n\nThe number of events in these two root files is different! I can't compare them!\n")
+    print(filename1)
+    print(filename2)
+    print("\n")
+    sys.exit()
+
+for ev in range(num_of_events1):
+    print("\nComparing event n.", ev , " ...")
+    exec('pic1=rootFile1.pic_run1_ev'+str(ev))
+    exec('pic2=rootFile2.pic_run1_ev'+str(ev))
+
+    x_bins = pic1.GetNbinsX()
+    y_bins = pic1.GetNbinsY()
+
+    bins1 = np.zeros((x_bins,y_bins))
+
+    for y_bin in range(y_bins): 
+        for x_bin in range(x_bins): 
+            bins1[x_bin,y_bin] = pic1.GetBinContent(x_bin + 1,y_bin + 1)
+
+    x_bins = pic2.GetNbinsX()
+    y_bins = pic2.GetNbinsY()
+
+    bins2 = np.zeros((x_bins,y_bins))
+
+    for y_bin in range(y_bins): 
+        for x_bin in range(x_bins): 
+            bins2[x_bin,y_bin] = pic2.GetBinContent(x_bin + 1,y_bin + 1)
+
+
+    if (bins1 == bins2).all():
+        print("Comparison result: equal\n")
+    else:
+        print("Comparison result: not equal\n")
+

--- a/srim2root.py
+++ b/srim2root.py
@@ -1,0 +1,80 @@
+from ROOT import TFile, TTree
+from array import array
+import pandas as pd
+
+
+# example used to create a root tree in python:
+#         https://root-forum.cern.ch/t/filling-branch-with-pyroot-limited/34744
+
+
+# NOTE: this code doesn't create a ntuple for phi_ini, theta_ini and energy_ini yet.
+#       So you can't use these quantities in the digitization code, if using a ROOT file converted from SRIM
+
+
+# set here input file and input folder
+infile="ionization_profile_He_10keV.txt"
+infolder="/home/pietro/Analysis_TESI/srim2root/SRIM_files/QF/"
+
+
+
+srim_df = pd.read_csv(infolder+infile, 
+                  sep='\t', 
+                  names=["ion_number",
+                         "hit_number",
+                         "primary_secondary",
+                         "X",                          # [mm]
+                         "Y",                          # [mm]
+                         "Z",                          # [mm]
+                         "energy_deposit",             # [keV]
+                         "ionization_energy_deposit"]  # [keV]
+                     )
+
+# remove NaN rows
+srim_df.dropna() 
+
+infilename=infile[:-4]  
+outfile=TFile('%s.root' % (infilename), 'RECREATE')       
+
+
+outtree = TTree( 'nTuple', 'nTuple' )
+
+max_hits = 99999   # max number of hits per event
+eventnumber_data = array( 'i', [ 0 ] )
+numhits_data = array( 'i', [ 0 ] )
+particle_type_data =  array( 'i', [ 0 ] )
+x_hits_data = array( 'f', max_hits*[ 0] )
+y_hits_data = array( 'f', max_hits*[ 0] )
+z_hits_data = array( 'f', max_hits*[ 0] )
+energyDep_hits_data = array( 'f', max_hits*[ 0] )
+
+
+# see the number of events in srim file
+events= 5  ##srim_df.Ion_number.iloc[-1]
+
+outtree.Branch( 'eventnumber', eventnumber_data, 'eventnumber/I' )
+outtree.Branch( 'numhits', numhits_data, 'numhits/I' )
+outtree.Branch( 'particle_type', particle_type_data, 'particle_type/I' )
+outtree.Branch( 'x_hits', x_hits_data, 'x_hits[numhits]/F' )
+outtree.Branch( 'y_hits', y_hits_data, 'y_hits[numhits]/F' )
+outtree.Branch( 'z_hits', z_hits_data, 'z_hits[numhits]/F' )
+outtree.Branch( 'energyDep_hits', energyDep_hits_data, 'energyDep_hits[numhits]/F' )
+
+
+     
+for ev in range(0,events):
+    eventnumber_data[0] = ev                                             # event number
+    numhits_data[0] = len(srim_df[srim_df["ion_number"]==ev+1].index)    # number of hits
+    particle_type_data[0] = 1
+    
+    
+    for hit in range(0,numhits_data[0]):
+        x_hits_data[hit] = srim_df[srim_df.ion_number==ev+1]["X"].iloc[hit]
+        y_hits_data[hit] = srim_df[srim_df.ion_number==ev+1]["Y"].iloc[hit]
+        z_hits_data[hit] = srim_df[srim_df.ion_number==ev+1]["Z"].iloc[hit]
+        energyDep_hits_data[hit] = srim_df[srim_df.ion_number==ev+1]["ionization_energy_deposit"].iloc[hit]
+    
+    outtree.Fill()
+    print("Processing event n.: ", ev, end="\r")
+    
+outfile.Write()
+outfile.Close()

--- a/swiftlib.py
+++ b/swiftlib.py
@@ -3,7 +3,7 @@
 def swift_root_file(tag, run):
     sel = rootlocation(tag,run)    
     
-    BASE_URL  = "https://swift.cloud.infn.it:8080/v1/AUTH_1e60fe39fba04701aa5ffc0b97871ed8/Cygnus/"
+    BASE_URL  = "https://s3.cloud.infn.it/v1/AUTH_2ebf769785574195bde2ff418deac08a/cygnus/"
     file_root = (sel+'/histograms_Run%05d.root' % run)
     return BASE_URL+file_root
 
@@ -33,7 +33,7 @@ def rootlocation(tag,run):
     if tag == 'Data':
         if (run>=936) and (run<=1601):
             sel = 'Data/LTD/Data_Camera/ROOT'
-        elif (run>=1632) and (run<=3865):
+        elif ((run>=1632) and (run<=3865)) or (run==4159):
             sel = 'Data/LAB'
         else:
             print("WARNING: Data taken with another DAQ or not yet uploaded to the cloud")


### PR DESCRIPTION
Improved code speed with minimal cuboid and numpy. Added a script to convert txt SRIM files into ROOT files. The conversion at the moment has to be done manually, but, if needed, it could be integrated in the main code to convert SRIM files automatically. The following quantities are not computed in the script: initial phi, initial theta, initial energy