### PR TITLE
Fix error when there are no electrons on GEM3 and small fix to custom background

### DIFF
--- a/ConfigFile_new.txt
+++ b/ConfigFile_new.txt
@@ -34,8 +34,8 @@
 'camera_aperture'       : 0.95,
 
 'bckg'                  : True,      # if 'True' background is added
-'NR'                    : True,     # 'True' for NR digitization, 'False' for ER   
-'events'                : 50,         # number of events to be processed, -1 = all
+'NR'                    : False,     # 'True' for NR digitization, 'False' for ER   
+'events'                : 2,         # number of events to be processed, -1 = all
 'donotremove'           : True,      # Remove or not the file from the tmp folder
 'fixed_seed'            : False,     # If 'True' the seed of random distributions is set to 0 (for debugging purposes)
 

--- a/ConfigFile_new.txt
+++ b/ConfigFile_new.txt
@@ -34,8 +34,8 @@
 'camera_aperture'       : 0.95,
 
 'bckg'                  : True,      # if 'True' background is added
-'NR'                    : False,     # 'True' for NR digitization, 'False' for ER   
-'events'                : 2,         # number of events to be processed, -1 = all
+'NR'                    : True,     # 'True' for NR digitization, 'False' for ER   
+'events'                : 50,         # number of events to be processed, -1 = all
 'donotremove'           : True,      # Remove or not the file from the tmp folder
 'fixed_seed'            : False,     # If 'True' the seed of random distributions is set to 0 (for debugging purposes)
 

--- a/MC_data_new.py
+++ b/MC_data_new.py
@@ -104,7 +104,7 @@ def Nph_saturation_vectorized(histo_cloud,options):
 def AddBckg(options, i):
     bckg_array=np.zeros((options.x_pix,options.y_pix))
     if options.bckg:
-        if options.bckg_path:
+        if os.path.exists("%s/histograms_Run%05d.root" % (options.bckg_path,int(options.noiserun))):
             options.tmpname = "%s/histograms_Run%05d.root" % (options.bckg_path,int(options.noiserun))
         elif sw.checkfiletmp(int(options.noiserun)):
             #FIXME

--- a/MC_data_new.py
+++ b/MC_data_new.py
@@ -290,7 +290,6 @@ if __name__ == "__main__":
 
                         # if there are no electrons on GEM3, just use empty image 
                         if S3D_x.size == 0: 
-                           print("empty image")
                            array2d_Nph = np.zeros((opt.x_pix,opt.y_pix))
 
                         # if there are electrons on GEM3, apply saturation effect 


### PR DESCRIPTION
1 - if you digitize events at very low energies (example NR under 1keV), it can happen that in some events no electrons are produced from the GEM2, and the code stops with an error. Now, if there are no electrons, the code returns an empty image (with background, if it is on). 
2 - small fix: check if the background file is at the custom path (specified in the config file). If not, it searches the file in /tmp/, and if not found, it tries to download it.  

Code runs as usual. No differences in the images. 