### PR TITLE
Upload Fe55 configfile + add track length computation + use pedestal more than once

### DIFF
--- a/ConfigFile_Fe55_5867-5911.txt
+++ b/ConfigFile_Fe55_5867-5911.txt
@@ -1,46 +1,46 @@
 {
 ##from https://arxiv.org/pdf/2007.00608.pdf
-'diff_const_sigma0T'      : 0.1225,        # diffusion constant [mm]^2
-'diff_coeff_T'            : 0.013225,      # diffusion parameter [mm/sqrt(cm)]^2 for 1 kV
-'diff_const_sigma0L'      : 0.0676,        # diffusion constant [mm]^2
-'diff_coeff_L'            : 0.00978,       # diffusion parameter [mm/sqrt(cm)]^2 for 1 kV
+'diff_const_sigma0T'    : 0.1225,    # diffusion constant [mm]^2
+'diff_coeff_T'          : 0.013225,  # diffusion parameter [mm/sqrt(cm)]^2 for 1 kV
+'diff_const_sigma0L'    : 0.0676,    # diffusion constant [mm]^2
+'diff_coeff_L'          : 0.00978,   # diffusion parameter [mm/sqrt(cm)]^2 for 1 kV
 
-'x_dim'                   : 346.,          # first dimension of the detector
-'y_dim'                   : 346.,          # second dimension of the detector
-'x_pix'                   : 2304,          # number of pixels in the first dimension
-'y_pix'                   : 2304,          # number of pixels in the second dimension
+'x_dim'                 : 346,       # first dimension of the detector
+'y_dim'                 : 346,       # second dimension of the detector
+'x_pix'                 : 2304,      # number of pixels in the first dimension
+'y_pix'                 : 2304,      # number of pixels in the second dimension
 
 #FIXME
-'z_gem'                   : 255.+250.,     # GEM z coordinate [mm]. Always add 255mm since in Geant4 center of sensitive region is at 255mm
-'tag'                     : 'Data',        # Set 'Data' to download a real pedestal run 
-'noiserun'                : 5861,          # pedestal run to add as background
-'bckg_path'               : '/tmp/',       # set path to pedestal run, or leave it black if you want to download it
+'z_gem'                 : 255.+250., # GEM z coordinate [mm]. Always add 255mm since in Geant4 center of sensitive region is at 255mm
+'tag'                   : 'Data',    # Set 'Data' to download a real pedestal run 
+'noiserun'              : 5861,      # pedestal run to add as background
+'bckg_path'             : '/tmp/',   # set path to pedestal run, or leave it black if you want to download it
 
-'ion_pot'                 : 0.0462,        # ionization potential for He/CF4 60/40 [keV]
-'GEM1_HV'                 : 440.,          # HV of GEM1
-'GEM2_HV'                 : 440.,          # HV of GEM2
-'GEM3_HV'                 : 440.,          # HV of GEM3
+'ion_pot'               : 0.0462,    # ionization potential for He/CF4 60/40 [keV]
+'GEM1_HV'               : 440.,      # HV of GEM1
+'GEM2_HV'               : 440.,      # HV of GEM2
+'GEM3_HV'               : 440.,      # HV of GEM3
 
 # saturation parameters
-'saturation'              : True,          # if 'True' saturation effect is applied on GEM3    
-'x_vox_dim'               : 346./2304.,    # x voxel size in [mm]
-'y_vox_dim'               : 346./2304.,    # y voxel size in [mm]
-'z_vox_dim'               : 0.1,           # z voxel size in [mm]
-'A'                       : 1.52,          # free parameter (total scale factor MC/data) 
-'beta'                    : 1.0e-5,        # saturation parameter
+'saturation'            : True,      # if 'True' saturation effect is applied on GEM3    
+'x_vox_dim'             : 346./2304, # x voxel size in [mm]
+'y_vox_dim'             : 346./2304, # y voxel size in [mm]
+'z_vox_dim'             : 0.1,       # z voxel size in [mm]
+'A'                     : 1.52,      # free parameter (total scale factor MC/data) 
+'beta'                  : 1.0e-5,    # saturation parameter
 
 # optical parameters
-'photons_per_el'          : 0.07,          # number of photons per electron produced in the avalanche
-'counts_per_photon'       : 2.,            # sensor conversion factor counts/photons
-'sensor_size'             : 14.976,        # sensor dimension [mm] ORCA Fusion
-'camera_aperture'         : 0.95,
+'photons_per_el'        : 0.07,      # number of photons per electron produced in the avalanche
+'counts_per_photon'     : 2.,        # sensor conversion factor counts/photons
+'sensor_size'           : 14.976,    # sensor dimension [mm] ORCA Fusion
+'camera_aperture'       : 0.95,
 
-'bckg'                    : True,          # if 'True' background is added
-'NR'                      : False,         # 'True' for NR digitization, 'False' for ER   
-'events'                  : 100,           # number of events to be processed, -1 = all
-'donotremove'             : True,          # Remove or not the file from the tmp folder
-'fixed_seed'              : False,         # If 'True' the seed of random distributions is set to 0 (for debugging purposes)
+'bckg'                  : True,      # if 'True' background is added
+'NR'                    : False,     # 'True' for NR digitization, 'False' for ER   
+'events'                : 100,       # number of events to be processed, -1 = all
+'donotremove'           : True,      # Remove or not the file from the tmp folder
+'fixed_seed'            : False,     # If 'True' the seed of random distributions is set to 0 (for debugging purposes)
 
-'randZ_range'             : 0.,            # Track z coordinate range [mm]. Tracks will be generated uniformly between 'z_hit+randZ_range/2' and 'z_hit-randZ_range/2'  
-'absorption_l'            : 1400.,         # absorption lenght in [mm]
+'randZ_range'           : 0.,        # Track z coordinate range [mm]. Tracks will be generated uniformly between 'z_hit+randZ_range/2' and 'z_hit-randZ_range/2'  
+'absorption_l'          : 1400.,     # absorption lenght in [mm]
 }

--- a/ConfigFile_Fe55_5867-5911.txt
+++ b/ConfigFile_Fe55_5867-5911.txt
@@ -1,0 +1,46 @@
+{
+##from https://arxiv.org/pdf/2007.00608.pdf
+'diff_const_sigma0T'      : 0.1225,        # diffusion constant [mm]^2
+'diff_coeff_T'            : 0.013225,      # diffusion parameter [mm/sqrt(cm)]^2 for 1 kV
+'diff_const_sigma0L'      : 0.0676,        # diffusion constant [mm]^2
+'diff_coeff_L'            : 0.00978,       # diffusion parameter [mm/sqrt(cm)]^2 for 1 kV
+
+'x_dim'                   : 346.,          # first dimension of the detector
+'y_dim'                   : 346.,          # second dimension of the detector
+'x_pix'                   : 2304,          # number of pixels in the first dimension
+'y_pix'                   : 2304,          # number of pixels in the second dimension
+
+#FIXME
+'z_gem'                   : 255.+250.,     # GEM z coordinate [mm]. Always add 255mm since in Geant4 center of sensitive region is at 255mm
+'tag'                     : 'Data',        # Set 'Data' to download a real pedestal run 
+'noiserun'                : 5861,          # pedestal run to add as background
+'bckg_path'               : '/tmp/',       # set path to pedestal run, or leave it black if you want to download it
+
+'ion_pot'                 : 0.0462,        # ionization potential for He/CF4 60/40 [keV]
+'GEM1_HV'                 : 440.,          # HV of GEM1
+'GEM2_HV'                 : 440.,          # HV of GEM2
+'GEM3_HV'                 : 440.,          # HV of GEM3
+
+# saturation parameters
+'saturation'              : True,          # if 'True' saturation effect is applied on GEM3    
+'x_vox_dim'               : 346./2304.,    # x voxel size in [mm]
+'y_vox_dim'               : 346./2304.,    # y voxel size in [mm]
+'z_vox_dim'               : 0.1,           # z voxel size in [mm]
+'A'                       : 1.52,          # free parameter (total scale factor MC/data) 
+'beta'                    : 1.0e-5,        # saturation parameter
+
+# optical parameters
+'photons_per_el'          : 0.07,          # number of photons per electron produced in the avalanche
+'counts_per_photon'       : 2.,            # sensor conversion factor counts/photons
+'sensor_size'             : 14.976,        # sensor dimension [mm] ORCA Fusion
+'camera_aperture'         : 0.95,
+
+'bckg'                    : True,          # if 'True' background is added
+'NR'                      : False,         # 'True' for NR digitization, 'False' for ER   
+'events'                  : 100,           # number of events to be processed, -1 = all
+'donotremove'             : True,          # Remove or not the file from the tmp folder
+'fixed_seed'              : False,         # If 'True' the seed of random distributions is set to 0 (for debugging purposes)
+
+'randZ_range'             : 0.,            # Track z coordinate range [mm]. Tracks will be generated uniformly between 'z_hit+randZ_range/2' and 'z_hit-randZ_range/2'  
+'absorption_l'            : 1400.,         # absorption lenght in [mm]
+}

--- a/MC_data_new.py
+++ b/MC_data_new.py
@@ -289,6 +289,51 @@ if __name__ == "__main__":
                 outtree.Branch("theta_ini", theta_ini, "theta_ini/F")
                 outtree.Branch("phi_ini", phi_ini, "phi_ini/F")
 
+                ### saving track lenth##
+                param_tree = rt.TTree("param_tree","param_tree") #creating a tree
+
+                track_length_3D=np.empty((1),dtype="float32")
+                x_vertex=np.empty((1),dtype="float32")
+                y_vertex=np.empty((1),dtype="float32")
+                z_vertex=np.empty((1),dtype="float32")
+                x_vertex_end=np.empty((1),dtype="float32")
+                y_vertex_end=np.empty((1),dtype="float32")
+                z_vertex_end=np.empty((1),dtype="float32")
+                energy = np.empty((1),dtype="float32")
+                px = np.empty((1),dtype="float32")
+                py = np.empty((1),dtype="float32")
+                pz = np.empty((1),dtype="float32")
+                proj_track_2D= np.empty((1),dtype="float32")
+                theta = np.empty((1),dtype = "float32")
+                phi = np.empty((1),dtype = "float32")
+                nhits_og = np.empty((1),dtype = "int32")
+                xhits_og = np.empty((10000),dtype = "float32")
+                yhits_og = np.empty((10000),dtype = "float32")
+                zhits_og = np.empty((10000),dtype = "float32")
+                EDepHit_og = np.empty((10000),dtype = "float32")
+
+                
+                param_tree.Branch('track_length_3D',track_length_3D,"track_length_3D/F")
+                param_tree.Branch('proj_track_2D',proj_track_2D,"proj_track_2D/F")
+                param_tree.Branch('x_vertex',x_vertex,"x_vertex/F")
+                param_tree.Branch('y_vertex',y_vertex,"y_vertex/F")
+                param_tree.Branch('z_vertex',z_vertex,"z_vertex/F")
+                param_tree.Branch('x_vertex_end',x_vertex_end,"x_vertex_end/F")
+                param_tree.Branch('y_vertex_end',y_vertex_end,"y_vertex_end/F")
+                param_tree.Branch('z_vertex_end',z_vertex_end,"z_vertex_end/F")
+                param_tree.Branch('energy',energy,"energy/F")
+                param_tree.Branch('px',px,"px/F")
+                param_tree.Branch('py',py,"py/F")
+                param_tree.Branch('pz',pz,"pz/F")
+                param_tree.Branch('theta',theta,"theta/F")
+                param_tree.Branch('phi',phi,"phi/F") 
+                param_tree.Branch('nhits_og',nhits_og,"nhits_og/I")
+                param_tree.Branch('xhits_og',xhits_og,"xhits_og[nhits_og]/F")
+                param_tree.Branch('yhits_og',yhits_og,"yhits_og[nhits_og]/F")
+                param_tree.Branch('zhits_og',zhits_og,"zhits_og[nhits_og]/F")
+                param_tree.Branch('EDepHit_og',EDepHit_og,"EDepHit_og[nhits_og]/F")  
+
+
                 final_imgs=list();
                 
                 if opt.events==-1:
@@ -304,19 +349,7 @@ if __name__ == "__main__":
     
                 for entry in range(0, totev): #RUNNING ON ENTRIES
                     tree.GetEntry(entry)
-                    eventnumber[0] = tree.eventnumber
-                    #FIXME
-                    if (opt.NR==True): 
-                        energy_ini[0] = tree.ekin_particle
-                        particle_type[0] = tree.particle_type
-                    else: 
-                        energy_ini[0] = tree.ekin_particle[0]*1000
-                        particle_type[0] = 0
-                    phi_ini[0] = -999.
-                    theta_ini[0] = -999.
-                    phi_ini[0] = np.arctan2( (tree.y_hits[1]-tree.y_hits[0]),(tree.z_hits[1]-tree.z_hits[0]) )
-                    theta_ini[0] = np.arccos( (tree.x_hits[1]-tree.x_hits[0]) / np.sqrt( np.power((tree.x_hits[1]-tree.x_hits[0]),2) + np.power((tree.y_hits[1]-tree.y_hits[0]),2) + np.power((tree.z_hits[1]-tree.z_hits[0]),2)) )
-                    outtree.Fill()
+
 
                     # add random Z to tracks
                     x_hits_tr = tree.x_hits
@@ -324,6 +357,44 @@ if __name__ == "__main__":
                         rand = (random.random()-0.5)*(opt.randZ_range)
                         for ihit in range(0,tree.numhits):
                             x_hits_tr[ihit]+=rand
+
+
+                    eventnumber[0] = tree.eventnumber
+                    #FIXME
+                    if (opt.NR==True): 
+                        proj_track_2D[0]=np.sum(np.sqrt(np.power(np.ediff1d(np.array(tree.x_hits)),2)+np.power(np.ediff1d(np.array(tree.y_hits)),2)))
+                        energy_ini[0] = tree.ekin_particle
+                        particle_type[0] = tree.particle_type
+                    else: 
+                        proj_track_2D[0]=np.sum(np.sqrt(np.power(np.ediff1d(np.array(tree.z_hits)),2)+np.power(np.ediff1d(np.array(tree.y_hits)),2)))
+                        energy_ini[0] = tree.ekin_particle[0]*1000
+                        particle_type[0] = 0
+                    phi_ini[0] = -999.
+                    theta_ini[0] = -999.
+                    phi_ini[0] = np.arctan2( (tree.y_hits[1]-tree.y_hits[0]),(tree.z_hits[1]-tree.z_hits[0]) )
+                    theta_ini[0] = np.arccos( (tree.x_hits[1]-tree.x_hits[0]) / np.sqrt( np.power((tree.x_hits[1]-tree.x_hits[0]),2) + np.power((tree.y_hits[1]-tree.y_hits[0]),2) + np.power((tree.z_hits[1]-tree.z_hits[0]),2)) )
+                    track_length_3D[0]=np.sum(np.array(tree.tracklen_hits))
+                    xhits_og = np.array(x_hits_tr)
+                    yhits_og = np.array(tree.y_hits)
+                    zhits_og = np.array(tree.z_hits)
+                    EDepHit_og = np.array(tree.energyDep_hits)
+                    px[0]= np.array(tree.px_particle)[0]
+                    py[0]= np.array(tree.py_particle)[0]
+                    pz[0]= np.array(tree.pz_particle)[0]
+                    x_vertex[0]= np.array(x_hits_tr)[0]
+                    y_vertex[0]= (np.array(tree.y_vertex_hits)[0]+0.5*opt.y_dim)*opt.y_pix/opt.y_dim
+                    z_vertex[0]= (np.array(tree.z_vertex_hits)[0]+0.5*opt.x_dim)*opt.x_pix/opt.x_dim
+                    x_vertex_end[0]= np.array(x_hits_tr)[-1]
+                    y_vertex_end[0]= (np.array(tree.y_vertex_hits)[-1]+0.5*opt.y_dim)*opt.y_pix/opt.y_dim
+                    z_vertex_end[0]= (np.array(tree.z_vertex_hits)[-1]+0.5*opt.x_dim)*opt.x_pix/opt.x_dim
+                    energy[0]=energy_ini[0]
+                    theta[0]=theta_ini[0]
+                    phi[0]=phi_ini[0]
+                    nhits_og[0]=tree.numhits
+                    
+
+                    outtree.Fill()
+
 
 
                     ## with saturation
@@ -347,9 +418,9 @@ if __name__ == "__main__":
                         # vectorized smearing
                         # if ER file need to swapp X with Z beacuse in geant the drift axis is X
                         if (opt.NR == True):
-                            S3D_x, S3D_y, S3D_z = cloud_smearing3D_vectorized(np.array(tree.x_hits),np.array(tree.y_hits),np.array(tree.z_hits),np.array(tree.energyDep_hits),opt)
+                            S3D_x, S3D_y, S3D_z = cloud_smearing3D_vectorized(np.array(x_hits_tr),np.array(tree.y_hits),np.array(tree.z_hits),np.array(tree.energyDep_hits),opt)
                         else:
-                            S3D_x, S3D_y, S3D_z = cloud_smearing3D_vectorized(np.array(tree.z_hits),np.array(tree.y_hits),np.array(tree.x_hits),np.array(tree.energyDep_hits),opt)
+                            S3D_x, S3D_y, S3D_z = cloud_smearing3D_vectorized(np.array(tree.z_hits),np.array(tree.y_hits),np.array(x_hits_tr),np.array(tree.energyDep_hits),opt)
 
 
                         # if there are no electrons on GEM3, just use empty image 
@@ -439,7 +510,9 @@ if __name__ == "__main__":
 
                     outfile.cd()
                     final_image.Write()            
+                    param_tree.Fill()
 
+                param_tree.Write()
                 outfile.cd('event_info') 
                 outtree.Write()
                 print('COMPLETED RUN %d'%(run_count))

--- a/MC_data_new.py
+++ b/MC_data_new.py
@@ -167,7 +167,8 @@ def AddBckg(options, i):
             print ('Downloading file: ' + sw.swift_root_file(options.tag, int(options.noiserun)))
             options.tmpname = sw.swift_download_root_file(sw.swift_root_file(options.tag, int(options.noiserun)),int(options.noiserun))
         tmpfile =rt.TFile.Open(options.tmpname)
-        tmphist = tmpfile.Get("pic_run%05d_ev%d"% (int(options.noiserun),i))
+        n_pics = len([k.GetName() for k in tmpfile.GetListOfKeys() if 'pic' in k.GetName()])
+        tmphist = tmpfile.Get("pic_run%05d_ev%d"% (int(options.noiserun),i%n_pics))
         bckg_array = rn.hist2array(tmphist) 
     #print(bckg_array)
     


### PR DESCRIPTION
1. Added config file with parameters that were tuned are (for Fe55 runs 5867-5911):

A= 1.52
abs_len= 1400 mm
diff_const_sigma0T= 0.1225 mm^2 (350 μm) (it actually stays the same as before)
diff_coeff_T= 0.013225 [mm/sqrt(cm)]^2 (115 μm/sqrt(cm))
noiserun = 5861

2. Add 3D/2D length track params and correct random z, as implemented by @SamueleTorelli. However, it seems 3D tracks are smaller than 2D projected tracks, on average. This is not normal, should be checked.

3. Use pedestal images more than once if needed 
Now, if you want, you can digitize N tracks even if you have less than N pedestal images: in case you have only P pedestals, the code will use the pedestal 0 multiple times, for the track 0, P, 2P, ... etc

  

